### PR TITLE
Rework libvirt setup and run script

### DIFF
--- a/docs/guest-types/index.rst
+++ b/docs/guest-types/index.rst
@@ -63,6 +63,13 @@ Currently, the emulator can act as a client to the other guests in the network i
 However, we currently don't support the emulator acting as a server to other guests - this may be supported in the future.
 You may have some success by utilising ADB to enable port forwards to the device or by editing the deploy script and adding Qemu options.
 
+NOTE: below is an explanation of how to manually connect to the emulator, the `kvm-compose` cli offers the following:
+```shell
+kvm-compose exec <guest name> adb <adb command>
+```
+To allow you to run commands on the emulator, without having to work out the namespaces etc.
+Make sure you are running this from the root of the project files (where the kvm-compose.yaml file lives).
+
 It is possible to utilise ADB to control the android guest remotely, however note that due to the emulator being in the namespace as mentioned above, the ADB server will also run inside the namespace and accept connections through the namespace's localhost.
 This only means any ADB commands must be executed using the namespace command, for example:
 

--- a/docs/kvm-compose/kvm-compose-yaml/libvirt.rst
+++ b/docs/kvm-compose/kvm-compose-yaml/libvirt.rst
@@ -12,7 +12,7 @@ cloud_image
 :environment: some variables that the guest is supplied in a key value store
 :context: a folder that should be mounted into the guest at `/etc/nocloud/context/`
 :setup_script: specify the setup script that will be run on orchestration
-:run_script: specify the run script that will be run at the end of orchestration
+:run_script: specify the run script that will be run when the guest is turned on (after setup_script if defined)
 
 existing_disk
 ~~~~~~~~~~~~~

--- a/docs/kvm-compose/kvm-compose-yaml/schema.rst
+++ b/docs/kvm-compose/kvm-compose-yaml/schema.rst
@@ -56,7 +56,7 @@ For example, the following are snippets of the relevant parts possible machine d
           gateway: 10.0.0.1
           mac: "00:00:00:00:00:01"
           ip: "10.0.0.10"
-      avd:
+      android:
         ...
 
 Machines - Libvirt
@@ -237,7 +237,34 @@ Further notes:
 
 Machines - AVD
 --------------
-Not yet implemented.
+
+The android section of the schema allows for two types of AVD, either `avd` or `existing_avd`.
+These are basically the same, where `existing_avd` points to an image created elsewhere.
+For `avd`, the testbed will create it for you based on the options given.
+
+For the moment `existing_avd` is unimplemented, this will be implemented in the future.
+
+To define either you must write:
+
+.. code-block:: yaml
+
+    android:
+      avd:
+        ...
+
+.. code-block:: yaml
+
+    android:
+      existing_avd:
+        ...
+
+For `avd` the options are as follows:
+
+:android_api_version: the API version of the operating system supported
+:playstore_enabled: whether the playstore will be installed or not (playstore enables various OS protections preventing tools that need root access)
+:setup_script: an arbritrary script that will be executed one the emulator is ready
+:run_script: an arbritary script that will be executed one the emulator is turned on (after setup_script, if defined)
+
 
 Network
 -------

--- a/kvm-compose/kvm-compose-schemas/src/exec.rs
+++ b/kvm-compose/kvm-compose-schemas/src/exec.rs
@@ -40,9 +40,11 @@ pub enum ExecCmdType {
 #[serde(rename_all = "snake_case")]
 pub struct ExecCmdShellCommand {
     #[clap(short, long, default_value="5000", help = "Timeout in milliseconds, defaults to 5s")]
-    pub timeout: u64,
+    pub timeout_ms: u64,
     #[clap(trailing_var_arg=true, index = 1)]
     pub command: Vec<String>,
+    #[clap(short, long, help = "Suppress all logging during command execution")]
+    pub suppress_logging: bool,
 }
 
 /// Represents the options for the push and pull file transfer sub-commands

--- a/kvm-compose/kvm-compose-schemas/src/kvm_compose_yaml/machines/avd.rs
+++ b/kvm-compose/kvm-compose-schemas/src/kvm_compose_yaml/machines/avd.rs
@@ -21,9 +21,12 @@ pub enum AVDGuestOptions {
     Avd {
         android_api_version: u8,
         playstore_enabled: bool,
+        setup_script: Option<PathBuf>,
+        run_script: Option<PathBuf>,
     },
     ExistingAvd {
         path: PathBuf,
+        run_script: Option<PathBuf>,
     }
 }
 

--- a/kvm-compose/kvm-compose-schemas/src/kvm_compose_yaml/machines/libvirt.rs
+++ b/kvm-compose/kvm-compose-schemas/src/kvm_compose_yaml/machines/libvirt.rs
@@ -39,6 +39,8 @@ pub enum LibvirtGuestOptions {
         path: Option<PathBuf>,
         run_script: Option<PathBuf>,
         setup_script: Option<PathBuf>,
+        #[serde(default = "default_setup_script_timeout")]
+        setup_script_timeout_s: u16,
         // TODO validate
         // #[validate(custom = "validate_context")]
         context: Option<PathBuf>,
@@ -70,6 +72,9 @@ pub enum LibvirtGuestOptions {
         readonly: bool,
     },
 }
+
+/// A default of 120 seconds for the timeout on running setup scripts, if user doesn't set their own
+fn default_setup_script_timeout() -> u16 {120}
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "lowercase")]

--- a/kvm-compose/kvm-compose/src/components/helpers/android.rs
+++ b/kvm-compose/kvm-compose/src/components/helpers/android.rs
@@ -55,7 +55,11 @@ pub fn get_sdk_string(
             }
 
             // always use x86 for now
-            package_string.push_str("x86");
+            if *android_api_version < 31 {
+                package_string.push_str("x86");
+            } else {
+                package_string.push_str("x86_64");
+            }
 
         }
         AVDGuestOptions::ExistingAvd { .. } => bail!("Existing AVD not yet implemented"),

--- a/kvm-compose/kvm-compose/src/components/helpers/android.rs
+++ b/kvm-compose/kvm-compose/src/components/helpers/android.rs
@@ -45,7 +45,7 @@ pub fn get_sdk_string(
     let mut package_string = "system-images;".to_string();
 
     match avdguest_options {
-        AVDGuestOptions::Avd { android_api_version, playstore_enabled } => {
+        AVDGuestOptions::Avd { android_api_version, playstore_enabled, .. } => {
             package_string.push_str(&format!("android-{android_api_version};"));
 
             if *playstore_enabled {

--- a/kvm-compose/kvm-compose/src/components/helpers/clones.rs
+++ b/kvm-compose/kvm-compose/src/components/helpers/clones.rs
@@ -131,6 +131,7 @@ pub fn generate_clone_guests(config: &mut Config) -> anyhow::Result<()> {
                                         path,
                                         run_script: _,
                                         setup_script: _,
+                                        setup_script_timeout_s: _,
                                         context,
                                         environment,
                                     } => LibvirtGuestOptions::CloudImage {
@@ -139,6 +140,7 @@ pub fn generate_clone_guests(config: &mut Config) -> anyhow::Result<()> {
                                         path: path.clone(),
                                         run_script: clone_run_script,
                                         setup_script: clone_setup_script,
+                                        setup_script_timeout_s: 120,
                                         context: context.clone(),
                                         environment: environment.clone(),
                                     },

--- a/kvm-compose/kvm-compose/src/components/helpers/clones.rs
+++ b/kvm-compose/kvm-compose/src/components/helpers/clones.rs
@@ -242,10 +242,14 @@ pub fn generate_clone_guests(config: &mut Config) -> anyhow::Result<()> {
                                 avd_type: match &avd_guest.avd_type {
                                     AVDGuestOptions::Avd {
                                         android_api_version,
-                                        playstore_enabled
+                                        playstore_enabled,
+                                        setup_script,
+                                        run_script,
                                     } => AVDGuestOptions::Avd {
                                         android_api_version: android_api_version.clone(),
                                         playstore_enabled: playstore_enabled.clone(),
+                                        setup_script: setup_script.clone(),
+                                        run_script: run_script.clone(),
                                     },
                                     AVDGuestOptions::ExistingAvd { .. } => {
                                         // need to create copies

--- a/kvm-compose/kvm-compose/src/exec/android.rs
+++ b/kvm-compose/kvm-compose/src/exec/android.rs
@@ -24,6 +24,7 @@ pub async fn adb_command(
     namespace: &str,
     command: &Vec<String>,
     logging_send: &Sender<OrchestrationLogger>,
+    suppress_output: bool,
 ) -> anyhow::Result<()> {
 
     let mut args = vec![
@@ -47,7 +48,9 @@ pub async fn adb_command(
     if output.status.success() {
         let log = String::from_utf8_lossy(&output.stdout);
         tracing::info!("ADB output: {:?}", String::from_utf8_lossy(&output.stdout));
-        logging_send.send(OrchestrationLogger::info(log.to_string())).await?;
+        if !suppress_output {
+            logging_send.send(OrchestrationLogger::info(log.to_string())).await?;
+        }
     } else {
         bail!("ADB error: {:?}", String::from_utf8_lossy(&output.stderr));
     }
@@ -86,7 +89,7 @@ pub async fn frida_setup(
     }
 
     // Run adb as root, push frida server to emulator and make it executable
-    let res = adb_command(namespace, &vec!["root".to_string()], &logging_send).await;
+    let res = adb_command(namespace, &vec!["root".to_string()], &logging_send, false).await;
     match res {
         Ok(_) => {}
         Err(e) => {
@@ -103,12 +106,12 @@ pub async fn frida_setup(
     tracing::info!("waiting to give a chance for rooting to complete before continuing ...");
     tokio::time::sleep(Duration::from_secs(2)).await;
 
-    adb_command(namespace, &vec!["push".to_string(), "/var/lib/testbedos/tools/frida-server-16.1.4-android-x86".to_string(), "/data/local/tmp".to_string()], &logging_send).await?;
-    adb_command(namespace, &vec!["shell".to_string(), "chmod".to_string(), "755".to_string(), "/data/local/tmp/frida-server-16.1.4-android-x86".to_string()], &logging_send).await?;
+    adb_command(namespace, &vec!["push".to_string(), "/var/lib/testbedos/tools/frida-server-16.1.4-android-x86".to_string(), "/data/local/tmp".to_string()], &logging_send, false).await?;
+    adb_command(namespace, &vec!["shell".to_string(), "chmod".to_string(), "755".to_string(), "/data/local/tmp/frida-server-16.1.4-android-x86".to_string()], &logging_send, false).await?;
 
     // Added -D to daemonize and -C to ignore crashes, which seems to prevent frida from holding
     // up the terminal so it exits - unclear if this is causing side effects yet
-    let res = adb_command(namespace, &vec!["shell".to_string(), "/data/local/tmp/frida-server-16.1.4-android-x86 -D -C".to_string()], &logging_send).await;
+    let res = adb_command(namespace, &vec!["shell".to_string(), "/data/local/tmp/frida-server-16.1.4-android-x86 -D -C".to_string()], &logging_send, false).await;
     match res {
         Ok(_) => {}
         Err(e) => {

--- a/kvm-compose/kvm-compose/src/exec/file_transfer.rs
+++ b/kvm-compose/kvm-compose/src/exec/file_transfer.rs
@@ -111,6 +111,7 @@ pub async fn mount_cdrom_in_guest(
         common,
         logging_send,
         true,
+        false,
     ).await?;
 
     logging_send.send(OrchestrationLogger::info(format!("Getting device output:\n{dev}"))).await?;
@@ -128,6 +129,7 @@ pub async fn mount_cdrom_in_guest(
         common,
         logging_send,
         true,
+        false,
     ).await?;
 
     // then mount the dev to an intermediate location
@@ -139,6 +141,7 @@ pub async fn mount_cdrom_in_guest(
         common,
         logging_send,
         true,
+        false,
     ).await?;
 
     if exit_code != 0 {
@@ -170,6 +173,7 @@ pub async fn move_pushed_file(
         common,
         logging_send,
         true,
+        false,
     ).await?;
 
     // use the destination provided by the user to move the file or folder from the mounted ISO to
@@ -182,6 +186,7 @@ pub async fn move_pushed_file(
         common,
         logging_send,
         true,
+        false,
     ).await?;
 
     if exit_code != 0 {
@@ -210,6 +215,7 @@ pub async fn unmount_and_detach_cdrom_from_guest(
         common,
         logging_send,
         true,
+        false,
     ).await?;
 
     if exit_code != 0 {

--- a/kvm-compose/kvm-compose/src/exec/file_transfer.rs
+++ b/kvm-compose/kvm-compose/src/exec/file_transfer.rs
@@ -110,6 +110,7 @@ pub async fn mount_cdrom_in_guest(
         guest_name_with_project,
         common,
         logging_send,
+        true,
     ).await?;
 
     logging_send.send(OrchestrationLogger::info(format!("Getting device output:\n{dev}"))).await?;
@@ -126,6 +127,7 @@ pub async fn mount_cdrom_in_guest(
         guest_name_with_project,
         common,
         logging_send,
+        true,
     ).await?;
 
     // then mount the dev to an intermediate location
@@ -136,6 +138,7 @@ pub async fn mount_cdrom_in_guest(
         guest_name_with_project,
         common,
         logging_send,
+        true,
     ).await?;
 
     if exit_code != 0 {
@@ -166,6 +169,7 @@ pub async fn move_pushed_file(
         guest_name_with_project,
         common,
         logging_send,
+        true,
     ).await?;
 
     // use the destination provided by the user to move the file or folder from the mounted ISO to
@@ -177,6 +181,7 @@ pub async fn move_pushed_file(
         guest_name_with_project,
         common,
         logging_send,
+        true,
     ).await?;
 
     if exit_code != 0 {
@@ -204,6 +209,7 @@ pub async fn unmount_and_detach_cdrom_from_guest(
         guest_name_with_project,
         common,
         logging_send,
+        true,
     ).await?;
 
     if exit_code != 0 {

--- a/kvm-compose/kvm-compose/src/exec/file_transfer.rs
+++ b/kvm-compose/kvm-compose/src/exec/file_transfer.rs
@@ -166,7 +166,7 @@ pub async fn move_pushed_file(
 
     // in case the target destination doesn't exist
     let _ = shell_command(
-        vec!["mkdir", "-p", &transfer.target_path.display().to_string()],
+        vec!["sudo", "mkdir", "-p", &transfer.target_path.display().to_string()],
         5_000,
         guest_data,
         guest_name_with_project,
@@ -179,7 +179,7 @@ pub async fn move_pushed_file(
     // use the destination provided by the user to move the file or folder from the mounted ISO to
     // the target location
     let (output, exit_code) = shell_command(
-        vec!["cp", "-r", "/mnt/filepush/.", &transfer.target_path.display().to_string()],
+        vec!["sudo", "cp", "-r", "/mnt/filepush/.", &transfer.target_path.display().to_string()],
         5_000,
         guest_data,
         guest_name_with_project,

--- a/kvm-compose/kvm-compose/src/exec/libvirt.rs
+++ b/kvm-compose/kvm-compose/src/exec/libvirt.rs
@@ -1,4 +1,5 @@
 use std::ops::{Add};
+use std::time::Duration;
 use anyhow::{bail, Context, Error};
 use rexpect::process::{signal};
 use rexpect::ReadUntil;
@@ -6,6 +7,8 @@ use rexpect::session::PtySession;
 use tokio::sync::mpsc::{Sender};
 use tokio::sync::{mpsc};
 use console::strip_ansi_codes;
+use tokio::task::JoinHandle;
+use tokio::time;
 use kvm_compose_schemas::exec::ExecCmdFileTransfer;
 use kvm_compose_schemas::kvm_compose_yaml::machines::GuestType;
 use crate::exec::file_transfer::*;
@@ -85,61 +88,17 @@ pub async fn shell_command(
     // set up a channel to send logging from the command running
     let (cmd_log_sender, mut cmd_log_receiver) = mpsc::channel(16);
 
-    // run the rexpect code in a blocking thread (to prevent locking up the server), while sending
-    // logging results in a channel
-    // also return the possible exit code to be parsed at the end to be returned to the caller and
-    // via logging to the user
-    let tty = tokio::task::spawn_blocking(move || {
-        // spawn the pty in the expect session
-        // TODO - CLI configurable timeout?
-        let mut pty = rexpect::spawn(&virsh_cmd, Some(timeout))
-            .context("rexpect error")?;
-
-        // we need to know if virsh will let us open the pty or there is already a connection to it
-        let intial_state = determine_initial_pty_state(&mut pty)
-            .context("getting initial state of tty")?;
-        match intial_state {
-            PtyInitialState::SessionOpen => bail!("there was already a tty session open to the guest, cannot continue"),
-            _ => {}
-        }
-        // we have a connection
-        cmd_log_sender.blocking_send("Successfully opened PTY session to guest".to_string())?;
-
-        // we send a new line command to dismiss the virsh escape character message
-        pty.send_line("")?;
-
-        pty_state_loop(&mut pty, &username, &password, &shell_user_host_string, &cmd_log_sender)?;
-
-        // the shell is open, we can finally run the command
-        cmd_log_sender.blocking_send(format!("Running command ({usr_cmd}) on guest"))?;
-        pty.send_line(&usr_cmd)?;
-
-        // check if there was a password prompt, otherwise get result
-        let res = pty_state_loop(&mut pty, &username, &password, &shell_user_host_string, &cmd_log_sender)?;
-
-        // grab the command exit code, but prepend a space to not save it in the history
-        cmd_log_sender.blocking_send("Getting command exit code".to_string())?;
-        pty.send_line(" echo $?")?;
-        let exit_code_res = pty.exp_string(&shell_user_host_string)?;
-        // the exit code will include the new terminal line below, so we need to trim that
-        let mut exit_code_lines = exit_code_res.lines();
-        exit_code_lines.next();
-        let exit_code = exit_code_lines.next();
-        //cmd_log_sender.blocking_send(format!("Command exit code:\n{:?}", exit_code))?;
-
-        cmd_log_sender.blocking_send("Sending close command to PTY".to_string())?;
-        pty.send("\x1D")?;
-        pty.process.kill(signal::SIGKILL)?;
-
-        // return both the output of the command and the exit code
-        // need to push the exit code if okay as a string rather than &str
-        let exit_code_string = if exit_code.is_some() {
-            Some(exit_code.unwrap().to_string())
-        } else {
-            None
-        };
-        Ok::<(String, Option<String>), Error>((res, exit_code_string))
-    });
+    // get the blocking thread that runs rexpect in a blocking context
+    let tty = begin_pty_thread(
+        virsh_cmd,
+        timeout,
+        username,
+        password,
+        shell_user_host_string,
+        usr_cmd,
+        cmd_log_sender.clone(),
+        true, // we will run the command the first time
+    );
 
     let command_exit_code;
     let command_output;
@@ -147,32 +106,49 @@ pub async fn shell_command(
     // loop to check if the command run has finished or not, but also check to see if there are log
     // messages to print before exiting - the pty will close itself as it has a timeout
     loop {
-        if cmd_log_receiver.is_empty() && tty.is_finished() {
-            // no more log messages and the pty has stopped running
-            let tty_res = tty.await?;
-            match tty_res {
-                Ok((output, exit_code)) => {
-                    if !suppress_logging {
-                        logging_send.send(OrchestrationLogger::info("PTY closed OK".to_string())).await?;
+        // we have to use a tokio select! here because there is a race condition between the tty
+        // thread finishing and reporting is_finished()==true and the log receiver waiting for the
+        // next message
+        tokio::select! {
+            msg = cmd_log_receiver.recv() => {
+                match msg {
+                    Some(msg) => {
+                        if !suppress_logging {
+                            logging_send.send(OrchestrationLogger::info(msg.to_string())).await?
+                        }
+                    },
+                    None => {
+                        // don't handle if the channel has been closed, we must wait for thread to close
+                        tracing::debug!("the exec command logging channel was unexpectedly closed");
                     }
-                    command_output = output;
-                    command_exit_code = exit_code;
-                },
-                Err(err) => bail!(err),
-            }
-            break;
-        }
-        // log messages in the queue
-        let msg = cmd_log_receiver.recv().await;
-        match msg {
-            Some(msg) => {
-                if !suppress_logging {
-                    logging_send.send(OrchestrationLogger::info(msg.to_string())).await?
                 }
-            },
-            None => {
-                // don't handle if the channel has been closed, we must wait for thread to close
-                tracing::debug!("the exec command logging channel was unexpectedly closed");
+            }
+            _ = time::sleep(Duration::from_millis(100)) => {
+                // this will execute every 100 if the above branch doesn't return
+                if cmd_log_receiver.is_empty() && tty.is_finished() {
+                    // no more log messages and the pty has stopped running
+                    let tty_res = tty.await?;
+                    match tty_res {
+                        Ok((output, exit_code)) => {
+                            if !suppress_logging {
+                                logging_send.send(OrchestrationLogger::info("PTY closed OK".to_string())).await?;
+                            }
+                            command_output = output;
+                            command_exit_code = exit_code;
+                        },
+                        Err(err) => {
+                            // the
+                            if err.to_string().contains("Timeout Error") {
+                                // in case there was a timeout error, we want to re-open the tty and
+                                // check again to see if the command was still running
+
+                                // TODO how to get the last output string if it bailed?
+                            }
+                            bail!(err);
+                        }
+                    }
+                    break;
+                }
             }
         }
     }
@@ -225,6 +201,84 @@ pub async fn shell_command(
     }
 
     Ok((final_command_output, parsed_exit_code))
+}
+
+fn begin_pty_thread(
+    virsh_cmd: String,
+    timeout: u64,
+    username: String,
+    password: String,
+    shell_user_host_string: String,
+    usr_cmd: String,
+    cmd_log_sender: Sender<String>,
+    run_command: bool,
+) -> JoinHandle<Result<(String, Option<String>), Error>> {
+    // run the rexpect code in a blocking thread (to prevent locking up the server), while sending
+    // logging results in a channel
+    // also return the possible exit code to be parsed at the end to be returned to the caller and
+    // via logging to the user
+    tokio::task::spawn_blocking(move || {
+
+        // get and start a PTY in a usable state
+        let mut pty = start_pty(&virsh_cmd, timeout, &cmd_log_sender)?;
+        // get the PTY into an open shell state
+        pty_state_loop(&mut pty, &username, &password, &shell_user_host_string, &cmd_log_sender)?;
+
+        if run_command {
+            // the shell is open, we can finally run the command
+            cmd_log_sender.blocking_send(format!("Running command ({usr_cmd}) on guest"))?;
+            pty.send_line(&usr_cmd)?;
+        }
+
+        // check if there was a password prompt, otherwise get result
+        let res = pty_state_loop(&mut pty, &username, &password, &shell_user_host_string, &cmd_log_sender)?;
+
+        // grab the command exit code, but prepend a space to not save it in the history
+        cmd_log_sender.blocking_send("Getting command exit code".to_string())?;
+        pty.send_line(" echo $?")?;
+        let exit_code_res = pty.exp_string(&shell_user_host_string)?;
+        // the exit code will include the new terminal line below, so we need to trim that
+        let mut exit_code_lines = exit_code_res.lines();
+        exit_code_lines.next();
+        let exit_code = exit_code_lines.next();
+
+        cmd_log_sender.blocking_send("Sending close command to PTY".to_string())?;
+        pty.send("\x1D")?;
+        pty.process.kill(signal::SIGKILL)?;
+
+        // return both the output of the command and the exit code
+        // need to push the exit code if okay as a string rather than &str
+        let exit_code_string = if exit_code.is_some() {
+            Some(exit_code.unwrap().to_string())
+        } else {
+            None
+        };
+        Ok::<(String, Option<String>), Error>((res, exit_code_string))
+    })
+}
+
+/// Start a pty session
+fn start_pty(
+    virsh_cmd: &String,
+    timeout: u64,
+    cmd_log_sender: &Sender<String>,
+) -> anyhow::Result<PtySession> {
+    // spawn the pty in the expect session
+    let mut pty = rexpect::spawn(&virsh_cmd, Some(timeout))
+        .context("rexpect error")?;
+    // we need to know if virsh will let us open the pty or there is already a connection to it
+    let intial_state = determine_initial_pty_state(&mut pty)
+        .context("getting initial state of tty")?;
+    match intial_state {
+        PtyInitialState::SessionOpen => bail!("there was already a tty session open to the guest, cannot continue"),
+        _ => {}
+    }
+    // we have a connection
+    cmd_log_sender.blocking_send("Successfully opened PTY session to guest".to_string())?;
+    // we send a new line command to dismiss the virsh escape character message
+    pty.send_line("")?;
+
+    Ok(pty)
 }
 
 /// Depending on whether the virsh console is currently in use or not, will determine whether we can

--- a/kvm-compose/kvm-compose/src/exec/libvirt.rs
+++ b/kvm-compose/kvm-compose/src/exec/libvirt.rs
@@ -51,6 +51,7 @@ pub async fn shell_command(
     _common: &OrchestrationCommon,
     logging_send: &Sender<OrchestrationLogger>,
     suppress_logging: bool,
+    ignore_outcome: bool,
 ) -> anyhow::Result<(String, i32)> {
 
     if !suppress_logging {
@@ -153,6 +154,15 @@ pub async fn shell_command(
         }
     }
 
+    // don't try to parse the outcome if true, this is to allow other systems that will manage their
+    // own completion systems (mainly the setup script and related code paths), as these will poll
+    // for their own completion flags on the system
+    // .. this is only needed because when using this by sending a command to the background, the
+    // command will push text to the terminal which messes up the following code
+    if ignore_outcome {
+        return Ok(("ignored outcome".to_string(), 0));
+    }
+
     // parse the outputs
     let ansi_strip_command_output = strip_ansi_codes(&command_output).to_string();
     let ansi_strip_command_exit_code = if let Some(exit_code) = command_exit_code {
@@ -241,6 +251,9 @@ fn begin_pty_thread(
         let mut exit_code_lines = exit_code_res.lines();
         exit_code_lines.next();
         let exit_code = exit_code_lines.next();
+
+        // cmd_log_sender.blocking_send(format!("Exited with code {:?}", exit_code))?;
+        // cmd_log_sender.blocking_send(format!("res: {}", res))?;
 
         cmd_log_sender.blocking_send("Sending close command to PTY".to_string())?;
         pty.send("\x1D")?;

--- a/kvm-compose/kvm-compose/src/exec/libvirt.rs
+++ b/kvm-compose/kvm-compose/src/exec/libvirt.rs
@@ -47,9 +47,12 @@ pub async fn shell_command(
     guest_name_with_project: &String,
     _common: &OrchestrationCommon,
     logging_send: &Sender<OrchestrationLogger>,
+    suppress_logging: bool,
 ) -> anyhow::Result<(String, i32)> {
 
-    logging_send.send(OrchestrationLogger::info(format!("Logging into guest {} pty", guest_name_with_project))).await?;
+    if !suppress_logging {
+        logging_send.send(OrchestrationLogger::info(format!("Logging into guest {} pty", guest_name_with_project))).await?;
+    }
     
     // TODO - here we should determine 
     //  1) what OS the guest is (this can be done with virt-inspector from guestfs-tools)
@@ -149,7 +152,9 @@ pub async fn shell_command(
             let tty_res = tty.await?;
             match tty_res {
                 Ok((output, exit_code)) => {
-                    logging_send.send(OrchestrationLogger::info("PTY closed OK".to_string())).await?;
+                    if !suppress_logging {
+                        logging_send.send(OrchestrationLogger::info("PTY closed OK".to_string())).await?;
+                    }
                     command_output = output;
                     command_exit_code = exit_code;
                 },
@@ -160,7 +165,11 @@ pub async fn shell_command(
         // log messages in the queue
         let msg = cmd_log_receiver.recv().await;
         match msg {
-            Some(msg) => logging_send.send(OrchestrationLogger::info(msg.to_string())).await?,
+            Some(msg) => {
+                if !suppress_logging {
+                    logging_send.send(OrchestrationLogger::info(msg.to_string())).await?
+                }
+            },
             None => {
                 // don't handle if the channel has been closed, we must wait for thread to close
                 tracing::debug!("the exec command logging channel was unexpectedly closed");
@@ -173,7 +182,9 @@ pub async fn shell_command(
     let ansi_strip_command_exit_code = if let Some(exit_code) = command_exit_code {
         strip_ansi_codes(&exit_code).to_string()
     } else {
-        logging_send.send(OrchestrationLogger::error(format!("Could not get exit code, got {command_exit_code:?} instead. Setting to -1"))).await?;
+        if !suppress_logging {
+            logging_send.send(OrchestrationLogger::error(format!("Could not get exit code, got {command_exit_code:?} instead. Setting to -1"))).await?;
+        }
         "-1".to_string()
     };
     // TODO - stripping carriage returns like this is likely to cause a weird edge case, how to avoid?
@@ -201,14 +212,16 @@ pub async fn shell_command(
     }
 
     // log the output depending on if the command worked or not
-    let cmd_output_string = format!("Command output:\n{}", final_command_output);
-    let finish_command_string = format!("Finished running command in guest {} pty, with exit code {}", guest_name_with_project, parsed_exit_code);
-    if parsed_exit_code != 0 {
-        logging_send.send(OrchestrationLogger::error(cmd_output_string)).await?;
-        logging_send.send(OrchestrationLogger::error(finish_command_string)).await?;
-    } else {
-        logging_send.send(OrchestrationLogger::info(cmd_output_string)).await?;
-        logging_send.send(OrchestrationLogger::info(finish_command_string)).await?;
+    if !suppress_logging {
+        let cmd_output_string = format!("Command output:\n{}", final_command_output);
+        let finish_command_string = format!("Finished running command in guest {} pty, with exit code {}", guest_name_with_project, parsed_exit_code);
+        if parsed_exit_code != 0 {
+            logging_send.send(OrchestrationLogger::error(cmd_output_string)).await?;
+            logging_send.send(OrchestrationLogger::error(finish_command_string)).await?;
+        } else {
+            logging_send.send(OrchestrationLogger::info(cmd_output_string)).await?;
+            logging_send.send(OrchestrationLogger::info(finish_command_string)).await?;
+        }
     }
 
     Ok((final_command_output, parsed_exit_code))

--- a/kvm-compose/kvm-compose/src/exec/libvirt.rs
+++ b/kvm-compose/kvm-compose/src/exec/libvirt.rs
@@ -154,15 +154,6 @@ pub async fn shell_command(
         }
     }
 
-    // don't try to parse the outcome if true, this is to allow other systems that will manage their
-    // own completion systems (mainly the setup script and related code paths), as these will poll
-    // for their own completion flags on the system
-    // .. this is only needed because when using this by sending a command to the background, the
-    // command will push text to the terminal which messes up the following code
-    if ignore_outcome {
-        return Ok(("ignored outcome".to_string(), 0));
-    }
-
     // parse the outputs
     let ansi_strip_command_output = strip_ansi_codes(&command_output).to_string();
     let ansi_strip_command_exit_code = if let Some(exit_code) = command_exit_code {
@@ -178,13 +169,6 @@ pub async fn shell_command(
     let ansi_strip_command_output = ansi_strip_command_output.replace("\r", "");
     let ansi_strip_command_exit_code = ansi_strip_command_exit_code.replace("\r", "");
 
-    // make sure exit code was a number
-    let maybe_int_exit_code = ansi_strip_command_exit_code.parse::<i32>();
-    let parsed_exit_code = match maybe_int_exit_code {
-        Ok(ok) => ok,
-        Err(_) => bail!("the command did not return an exit code: {:?}", maybe_int_exit_code),
-    };
-
     // the command output will also have the first line as the command input, as a side effect of
     // using expect - we need to remove it as we did for the exit code
     let mut command_output_lines = ansi_strip_command_output.lines();
@@ -196,6 +180,25 @@ pub async fn shell_command(
     if final_command_output.ends_with("\n") {
         final_command_output = final_command_output[0..final_command_output.len() - 1].to_string();
     }
+
+    // don't try to parse the outcome if true, this is to allow other systems that will manage their
+    // own completion systems (mainly the setup script and related code paths), as these will poll
+    // for their own completion flags on the system
+    // .. this is only needed because when using this by sending a command to the background, the
+    // command will push text to the terminal which messes up the following code
+    if ignore_outcome {
+        return Ok((final_command_output, 0));
+    }
+
+    // make sure exit code was a number
+    let maybe_int_exit_code = ansi_strip_command_exit_code.parse::<i32>();
+    let parsed_exit_code = match maybe_int_exit_code {
+        Ok(ok) => ok,
+        Err(_) => {
+            logging_send.send(OrchestrationLogger::error(format!("Output from script:\n{final_command_output}"))).await?;
+            bail!("the command did not return an exit code: {:?}", maybe_int_exit_code)
+        }
+    };
 
     // log the output depending on if the command worked or not
     if !suppress_logging {

--- a/kvm-compose/kvm-compose/src/exec/mod.rs
+++ b/kvm-compose/kvm-compose/src/exec/mod.rs
@@ -1,7 +1,7 @@
 pub mod android;
-mod docker;
-mod libvirt;
-mod file_transfer;
+pub mod docker;
+pub mod libvirt;
+pub mod file_transfer;
 
 use anyhow::{bail, Context};
 use tokio::sync::mpsc::Sender;
@@ -94,7 +94,7 @@ pub async fn run_guest_exec_cmd(
 
             let shell_command_result = match &guest_data.guest_type.guest_type {
                 GuestType::Libvirt(_) => {
-                    libvirt::shell_command(cmd, command.timeout, guest_data, &guest_name_with_project, orchestration_common, &logging_send).await?
+                    libvirt::shell_command(cmd, command.timeout_ms, guest_data, &guest_name_with_project, orchestration_common, &logging_send, command.suppress_logging).await?
                 }
                 GuestType::Docker(_) => {
                     docker::shell_command(cmd, guest_data, &guest_name_with_project, orchestration_common, &logging_send).await?

--- a/kvm-compose/kvm-compose/src/exec/mod.rs
+++ b/kvm-compose/kvm-compose/src/exec/mod.rs
@@ -94,7 +94,7 @@ pub async fn run_guest_exec_cmd(
 
             let shell_command_result = match &guest_data.guest_type.guest_type {
                 GuestType::Libvirt(_) => {
-                    libvirt::shell_command(cmd, command.timeout_ms, guest_data, &guest_name_with_project, orchestration_common, &logging_send, command.suppress_logging).await?
+                    libvirt::shell_command(cmd, command.timeout_ms, guest_data, &guest_name_with_project, orchestration_common, &logging_send, command.suppress_logging, false).await?
                 }
                 GuestType::Docker(_) => {
                     docker::shell_command(cmd, guest_data, &guest_name_with_project, orchestration_common, &logging_send).await?

--- a/kvm-compose/kvm-compose/src/exec/mod.rs
+++ b/kvm-compose/kvm-compose/src/exec/mod.rs
@@ -70,7 +70,7 @@ pub async fn run_guest_exec_cmd(
     guest_name: &String,
     guest_data: &StateTestbedGuest,
     exec_cmd: &ExecCmdType,
-    state: &State,
+    _state: &State,
     orchestration_common: &OrchestrationCommon,
     logging_send: &Sender<OrchestrationLogger>,
 ) -> anyhow::Result<bool> {
@@ -127,7 +127,7 @@ pub async fn run_guest_exec_cmd(
         }
         ExecCmdType::Tool(tool) => {
             tracing::info!("running tool on guest {guest_name_with_project}");
-            let namespace = format!("{}-{}-nmspc", state.project_name, guest_name_with_project);
+            let namespace = format!("{}-nmspc", guest_name_with_project);
             match &tool.tool {
                 TestbedTools::ADB(command) => {
                     tracing::info!("ADB arguments = {:?}", command.command);

--- a/kvm-compose/kvm-compose/src/exec/mod.rs
+++ b/kvm-compose/kvm-compose/src/exec/mod.rs
@@ -131,7 +131,7 @@ pub async fn run_guest_exec_cmd(
             match &tool.tool {
                 TestbedTools::ADB(command) => {
                     tracing::info!("ADB arguments = {:?}", command.command);
-                    android::adb_command(&namespace, &command.command, &logging_send).await?;
+                    android::adb_command(&namespace, &command.command, &logging_send, false).await?;
                 }
                 TestbedTools::FridaSetup => {
                     tracing::info!("Running frida tools setup commands");

--- a/kvm-compose/kvm-compose/src/orchestration/api.rs
+++ b/kvm-compose/kvm-compose/src/orchestration/api.rs
@@ -286,7 +286,7 @@ impl OrchestrationInstruction {
                 let mut res_name_list = Vec::new();
 
                 for create in create_list {
-                    create_futures.push(create.get_create_future(orchestration_common.clone()));
+                    create_futures.push(create.get_create_future(orchestration_common.clone(), logging_send));
                     res_name_list.push(create.name());
                 }
                 // join all futures and collect results
@@ -306,7 +306,7 @@ impl OrchestrationInstruction {
                 let mut res_name_list = Vec::new();
 
                 for create in destroy_list {
-                    destroy_futures.push(create.get_destroy_future(orchestration_common.clone()));
+                    destroy_futures.push(create.get_destroy_future(orchestration_common.clone(), logging_send));
                     res_name_list.push(create.name());
                 }
                 // join all futures and collect results
@@ -391,7 +391,7 @@ impl OrchestrationInstruction {
                 }
             }
             OrchestrationInstruction::ClearArtefacts => {
-                let res = clear_artefacts(state, orchestration_common).await;
+                let res = clear_artefacts(state, orchestration_common, logging_send).await;
                 match res {
                     Ok(_) => OrchestrationProtocolResponse::Generic { is_success: true, message: "Clearing Artefacts".to_string() },
                     Err(err) => OrchestrationProtocolResponse::Generic { is_success: false, message: format!("Clearing Artefacts, {err:#}") },
@@ -399,7 +399,7 @@ impl OrchestrationInstruction {
             }
             OrchestrationInstruction::SetupImage(list) => {
                 // this handles setting up backing images and clones of backing image
-                let response = Self::setup_image_helper(list, &orchestration_common).await;
+                let response = Self::setup_image_helper(list, &orchestration_common, logging_send).await;
                 response
             }
             OrchestrationInstruction::PushArtefacts(list) => {
@@ -409,7 +409,7 @@ impl OrchestrationInstruction {
                 let mut res_name_list = Vec::new();
 
                 for create in list {
-                    futures.push(create.get_push_image_future(orchestration_common.clone()));
+                    futures.push(create.get_push_image_future(orchestration_common.clone(), logging_send));
                     res_name_list.push(create.name());
                 }
                 // join all futures and collect results
@@ -478,7 +478,7 @@ impl OrchestrationInstruction {
                 let mut res_name_list = Vec::new();
 
                 for create in list {
-                    futures.push(create.get_rebase_clone_future(orchestration_common.clone(), state));
+                    futures.push(create.get_rebase_clone_future(orchestration_common.clone(), state, logging_send));
                     res_name_list.push(create.name());
                 }
                 // join all futures and collect results
@@ -498,7 +498,7 @@ impl OrchestrationInstruction {
                 let mut res_name_list = Vec::new();
 
                 for create in list {
-                    futures.push(create.get_run_setup_script_future(orchestration_common.clone()));
+                    futures.push(create.get_run_setup_script_future(orchestration_common.clone(), logging_send));
                     res_name_list.push(create.name());
                 }
                 // join all futures and collect results
@@ -533,7 +533,7 @@ impl OrchestrationInstruction {
                     let testbed_snapshots = TestbedSnapshots::new(&state, &orchestration_common).await?;
                     testbed_snapshots.snapshot_all_guests(&orchestration_common).await?;
                 }
-                match run_testbed_snapshot_action(&state, &orchestration_common).await {
+                match run_testbed_snapshot_action(&state, &orchestration_common, logging_send).await {
                     Ok(_) => OrchestrationProtocolResponse::Generic {
                         is_success: true,
                         message: "Created Testbed Snapshot".to_string(),
@@ -619,6 +619,7 @@ impl OrchestrationInstruction {
     async fn setup_image_helper(
         list: &Vec<OrchestrationResource>,
         orchestration_common: &OrchestrationCommon,
+        logging_send: &Sender<OrchestrationLogger>,
     ) -> OrchestrationProtocolResponse {
         // create futures and get the name list, since the vec is ordered by insertion then the name list will
         // be in the same order
@@ -626,7 +627,7 @@ impl OrchestrationInstruction {
         let mut res_name_list = Vec::new();
 
         for create in list {
-            create_futures.push(create.get_setup_image_future(orchestration_common.clone()));
+            create_futures.push(create.get_setup_image_future(orchestration_common.clone(), logging_send));
             res_name_list.push(create.name());
         }
         // join all futures and collect results
@@ -702,18 +703,18 @@ impl OrchestrationResource {
     }
 
     /// Get the future for the create action for the resource
-    pub async fn get_create_future(&self, orchestration_common: OrchestrationCommon) -> anyhow::Result<()> {
+    pub async fn get_create_future(&self, orchestration_common: OrchestrationCommon, logging_send: &Sender<OrchestrationLogger>) -> anyhow::Result<()> {
         match self {
             OrchestrationResource::Guest(guest) => {
                 match &guest.guest_type.guest_type {
                     GuestType::Libvirt(libvirt) => {
-                        libvirt.create_action(orchestration_common, guest.clone()).await
+                        libvirt.create_action(orchestration_common, guest.clone(), logging_send).await
                     }
                     GuestType::Docker(docker) => {
-                        docker.create_action(orchestration_common, guest.clone()).await
+                        docker.create_action(orchestration_common, guest.clone(), logging_send).await
                     }
                     GuestType::Android(android) => {
-                        android.create_action(orchestration_common, guest.clone()).await
+                        android.create_action(orchestration_common, guest.clone(), logging_send).await
                     }
                 }
             }
@@ -777,18 +778,18 @@ impl OrchestrationResource {
     }
 
     /// Get the future for the destroy action for the resource
-    pub async fn get_destroy_future(&self, orchestration_common: OrchestrationCommon) -> anyhow::Result<()> {
+    pub async fn get_destroy_future(&self, orchestration_common: OrchestrationCommon, logging_send: &Sender<OrchestrationLogger>) -> anyhow::Result<()> {
         match self {
             OrchestrationResource::Guest(guest) => {
                 match &guest.guest_type.guest_type {
                     GuestType::Libvirt(libvirt) => {
-                        libvirt.destroy_action(orchestration_common, guest.clone()).await
+                        libvirt.destroy_action(orchestration_common, guest.clone(), logging_send).await
                     }
                     GuestType::Docker(docker) => {
-                        docker.destroy_action(orchestration_common, guest.clone()).await
+                        docker.destroy_action(orchestration_common, guest.clone(), logging_send).await
                     }
                     GuestType::Android(android) => {
-                        android.destroy_action(orchestration_common, guest.clone()).await
+                        android.destroy_action(orchestration_common, guest.clone(), logging_send).await
                     }
                 }
             }
@@ -851,15 +852,15 @@ impl OrchestrationResource {
         }
     }
 
-    pub async fn get_push_image_future(&self, orchestration_common: OrchestrationCommon) -> anyhow::Result<()> {
+    pub async fn get_push_image_future(&self, orchestration_common: OrchestrationCommon, logging_send: &Sender<OrchestrationLogger>) -> anyhow::Result<()> {
         match self {
             OrchestrationResource::Guest(g) => {
                 match &g.guest_type.guest_type {
                     GuestType::Libvirt(l) => {
-                        l.push_image_action(orchestration_common, g.clone()).await
+                        l.push_image_action(orchestration_common, g.clone(), logging_send).await
                     }
                     GuestType::Docker(d) => {
-                        d.push_image_action(orchestration_common, g.clone()).await
+                        d.push_image_action(orchestration_common, g.clone(), logging_send).await
                     }
                     GuestType::Android(_) => unreachable!()
                 }
@@ -868,12 +869,12 @@ impl OrchestrationResource {
         }
     }
 
-    pub async fn get_setup_image_future(&self, orchestration_common: OrchestrationCommon) -> anyhow::Result<()> {
+    pub async fn get_setup_image_future(&self, orchestration_common: OrchestrationCommon, logging_sender: &Sender<OrchestrationLogger>) -> anyhow::Result<()> {
         match self {
             OrchestrationResource::Guest(g) => {
                 match &g.guest_type.guest_type {
                     GuestType::Libvirt(l) => {
-                        l.setup_image_action(orchestration_common, g.clone()).await
+                        l.setup_image_action(orchestration_common, g.clone(), logging_sender).await
                     }
                     GuestType::Docker(_) => unreachable!(),
                     GuestType::Android(_) => unreachable!()
@@ -883,12 +884,12 @@ impl OrchestrationResource {
         }
     }
 
-    pub async fn get_rebase_clone_future(&self, orchestration_common: OrchestrationCommon, state: &State) -> anyhow::Result<()> {
+    pub async fn get_rebase_clone_future(&self, orchestration_common: OrchestrationCommon, state: &State, logging_send: &Sender<OrchestrationLogger>) -> anyhow::Result<()> {
         match self {
             OrchestrationResource::Guest(g) => {
                 match &g.guest_type.guest_type {
                     GuestType::Libvirt(l) => {
-                        l.rebase_image_action(orchestration_common, g.clone(), state.testbed_guests.clone()).await
+                        l.rebase_image_action(orchestration_common, g.clone(), state.testbed_guests.clone(), logging_send).await
                     }
                     GuestType::Docker(_) => unreachable!(),
                     GuestType::Android(_) => unreachable!()
@@ -898,12 +899,12 @@ impl OrchestrationResource {
         }
     }
 
-    pub async fn get_run_setup_script_future(&self, orchestration_common: OrchestrationCommon) -> anyhow::Result<()> {
+    pub async fn get_run_setup_script_future(&self, orchestration_common: OrchestrationCommon, logging_send: &Sender<OrchestrationLogger>) -> anyhow::Result<()> {
         match self {
             OrchestrationResource::Guest(g) => {
                 match &g.guest_type.guest_type {
                     GuestType::Libvirt(l) => {
-                        l.setup_action(orchestration_common, g.clone()).await
+                        l.setup_action(orchestration_common, g.clone(), logging_send).await
                     }
                     GuestType::Docker(_) => unreachable!(),
                     GuestType::Android(_) => unreachable!()

--- a/kvm-compose/kvm-compose/src/orchestration/api.rs
+++ b/kvm-compose/kvm-compose/src/orchestration/api.rs
@@ -931,7 +931,9 @@ impl OrchestrationResource {
                         l.setup_action(orchestration_common, g.clone(), logging_send).await
                     }
                     GuestType::Docker(_) => unreachable!(),
-                    GuestType::Android(_) => unreachable!()
+                    GuestType::Android(a) => {
+                        a.setup_action(orchestration_common, g.clone(), logging_send).await
+                    }
                 }
             }
             OrchestrationResource::Network(_) => unreachable!(),
@@ -946,7 +948,9 @@ impl OrchestrationResource {
                         l.run_action(orchestration_common, g.clone(), logging_send).await
                     }
                     GuestType::Docker(_) => unreachable!(),
-                    GuestType::Android(_) => unreachable!()
+                    GuestType::Android(a) => {
+                        a.run_action(orchestration_common, g.clone(), logging_send).await
+                    }
                 }
             }
             OrchestrationResource::Network(_) => unreachable!(),

--- a/kvm-compose/kvm-compose/src/orchestration/api.rs
+++ b/kvm-compose/kvm-compose/src/orchestration/api.rs
@@ -105,6 +105,8 @@ pub enum OrchestrationInstruction {
     Edit(Vec<OrchestrationResource>),
     /// Run setup scripts for all guests in the list
     RunSetupScripts(Vec<OrchestrationResource>),
+    /// Execute the run script for all guests in the list
+    ExecuteRunScript(Vec<OrchestrationResource>),
     /// Run snapshot command for one guest
     Snapshot(SnapshotSubCommand),
     /// Run the testbed snapshot command
@@ -186,6 +188,10 @@ impl OrchestrationInstruction {
             }
             OrchestrationInstruction::RunSetupScripts(items) => {
                 instruction.push_str("Running Setup Scripts for ");
+                format_instruction_message(&mut instruction, items);
+            }
+            OrchestrationInstruction::ExecuteRunScript(items) => {
+                instruction.push_str("Executing Run Scripts for ");
                 format_instruction_message(&mut instruction, items);
             }
             OrchestrationInstruction::GenerateArtefacts{ .. } => instruction.push_str("Generate Artefacts"),
@@ -499,6 +505,24 @@ impl OrchestrationInstruction {
 
                 for create in list {
                     futures.push(create.get_run_setup_script_future(orchestration_common.clone(), logging_send));
+                    res_name_list.push(create.name());
+                }
+                // join all futures and collect results
+                let result = join_all(futures).await;
+
+                let mut result_messages = Vec::new();
+                // create message list
+                Self::format_message(result, &mut result_messages, res_name_list);
+
+                // finally return the response
+                OrchestrationProtocolResponse::List(result_messages)
+            }
+            OrchestrationInstruction::ExecuteRunScript(list) => {
+                let mut futures = Vec::new();
+                let mut res_name_list = Vec::new();
+
+                for create in list {
+                    futures.push(create.get_run_run_script_future(orchestration_common.clone(), logging_send));
                     res_name_list.push(create.name());
                 }
                 // join all futures and collect results
@@ -905,6 +929,21 @@ impl OrchestrationResource {
                 match &g.guest_type.guest_type {
                     GuestType::Libvirt(l) => {
                         l.setup_action(orchestration_common, g.clone(), logging_send).await
+                    }
+                    GuestType::Docker(_) => unreachable!(),
+                    GuestType::Android(_) => unreachable!()
+                }
+            }
+            OrchestrationResource::Network(_) => unreachable!(),
+        }
+    }
+
+    pub async fn get_run_run_script_future(&self, orchestration_common: OrchestrationCommon, logging_send: &Sender<OrchestrationLogger>) -> anyhow::Result<()> {
+        match self {
+            OrchestrationResource::Guest(g) => {
+                match &g.guest_type.guest_type {
+                    GuestType::Libvirt(l) => {
+                        l.run_action(orchestration_common, g.clone(), logging_send).await
                     }
                     GuestType::Docker(_) => unreachable!(),
                     GuestType::Android(_) => unreachable!()

--- a/kvm-compose/kvm-compose/src/orchestration/mod.rs
+++ b/kvm-compose/kvm-compose/src/orchestration/mod.rs
@@ -16,7 +16,7 @@ use tokio_tungstenite::tungstenite::Message;
 use kvm_compose_schemas::deployment_models::Deployment;
 use kvm_compose_schemas::settings::TestbedClusterConfig;
 use crate::components::LogicalTestbed;
-use crate::orchestration::api::OrchestrationProtocol;
+use crate::orchestration::api::{OrchestrationLogger, OrchestrationProtocol};
 use crate::orchestration::ssh::SSHClient;
 use crate::parse_config;
 use crate::state::{State, StateNetwork, StateTestbedGuest, StateTestbedGuestList, StateTestbedGuestSharedConfig, StateTestbedHost};
@@ -87,7 +87,7 @@ impl Default for OrchestrationCommon {
 pub trait OrchestrationTask {
     // These two are for creating resources all in one get
     async fn create_action(&self, common: &OrchestrationCommon) -> anyhow::Result<()>;
-    async fn destroy_action(&self, common: &OrchestrationCommon) -> anyhow::Result<()>;
+    async fn destroy_action(&self, common: &OrchestrationCommon, logging_sender: &Sender<OrchestrationLogger>) -> anyhow::Result<()>;
 
     // These two are for the client to request the server to create
     async fn request_create_action(&self, common: &OrchestrationCommon, sender: &mut Sender<OrchestrationProtocol>) -> anyhow::Result<()>;
@@ -103,15 +103,61 @@ pub trait OrchestrationTask {
 #[async_trait]
 pub trait OrchestrationGuestTask {
     // TODO - since were not using parallel tasks, we can revert back to just using references and remove usage of .clone()
-    async fn setup_image_action(&self, common: OrchestrationCommon, machine_config: StateTestbedGuest) -> anyhow::Result<()>;
-    async fn push_image_action(&self, common: OrchestrationCommon, machine_config: StateTestbedGuest) -> anyhow::Result<()>;
-    async fn pull_image_action(&self, common: OrchestrationCommon, machine_config: StateTestbedGuest) -> anyhow::Result<()>;
-    async fn rebase_image_action(&self, common: OrchestrationCommon, machine_config: StateTestbedGuest, guest_list: StateTestbedGuestList) -> anyhow::Result<()>;
-    async fn create_action(&self, common: OrchestrationCommon, machine_config: StateTestbedGuest) -> anyhow::Result<()>;
-    async fn setup_action(&self, common: OrchestrationCommon, machine_config: StateTestbedGuest) -> anyhow::Result<()>;
-    async fn run_action(&self, common: OrchestrationCommon, machine_config: StateTestbedGuest) -> anyhow::Result<()>;
-    async fn destroy_action(&self, common: OrchestrationCommon, machine_config: StateTestbedGuest) -> anyhow::Result<()>;
-    async fn is_up(&self, common: OrchestrationCommon, machine_config: StateTestbedGuest) -> anyhow::Result<bool>;
+    async fn setup_image_action(
+        &self,
+        common: OrchestrationCommon,
+        machine_config: StateTestbedGuest,
+        logging_sender: &Sender<OrchestrationLogger>,
+    ) -> anyhow::Result<()>;
+    async fn push_image_action(
+        &self,
+        common: OrchestrationCommon,
+        machine_config: StateTestbedGuest,
+        logging_sender: &Sender<OrchestrationLogger>,
+    ) -> anyhow::Result<()>;
+    async fn pull_image_action(
+        &self,
+        common: OrchestrationCommon,
+        machine_config: StateTestbedGuest,
+        logging_sender: &Sender<OrchestrationLogger>,
+    ) -> anyhow::Result<()>;
+    async fn rebase_image_action(
+        &self,
+        common: OrchestrationCommon,
+        machine_config: StateTestbedGuest,
+        guest_list: StateTestbedGuestList,
+        logging_sender: &Sender<OrchestrationLogger>,
+    ) -> anyhow::Result<()>;
+    async fn create_action(
+        &self,
+        common: OrchestrationCommon,
+        machine_config: StateTestbedGuest,
+        logging_sender: &Sender<OrchestrationLogger>,
+    ) -> anyhow::Result<()>;
+    async fn setup_action(
+        &self,
+        common: OrchestrationCommon,
+        machine_config: StateTestbedGuest,
+        logging_sender: &Sender<OrchestrationLogger>,
+    ) -> anyhow::Result<()>;
+    async fn run_action(
+        &self,
+        common: OrchestrationCommon,
+        machine_config: StateTestbedGuest,
+        logging_sender: &Sender<OrchestrationLogger>,
+    ) -> anyhow::Result<()>;
+    async fn destroy_action(
+        &self,
+        common: OrchestrationCommon,
+        machine_config: StateTestbedGuest,
+        logging_sender: &Sender<OrchestrationLogger>,
+    ) -> anyhow::Result<()>;
+    async fn is_up(
+        &self,
+        common: OrchestrationCommon,
+        machine_config: StateTestbedGuest,
+        logging_sender: &Sender<OrchestrationLogger>,
+    ) -> anyhow::Result<bool>;
 }
 
 /// Helper method to run sub commands since there is a lot of boilerplate. Also due to the need to

--- a/kvm-compose/kvm-compose/src/server_web_client/client.rs
+++ b/kvm-compose/kvm-compose/src/server_web_client/client.rs
@@ -32,9 +32,18 @@ pub async fn orchestration_action(
         }
     };
 
-    match &deployment.state {
-        DeploymentState::Running => bail!("deployment in Running state, cannot run orchestration command"),
-        _ => {}
+    match opts.sub_command {
+        SubCommand::Up(_) | SubCommand::Down | SubCommand::GenerateArtefacts |
+        SubCommand::ClearArtefacts | SubCommand::Snapshot(_) | SubCommand::TestbedSnapshot(_) => {
+            // these are destructive commands, don't allow running during other destructive cmds
+            match &deployment.state {
+                DeploymentState::Running => bail!("deployment in Running state, cannot run orchestration command"),
+                _ => {}
+            }
+        }
+        _ => {
+            // allow other commands
+        }
     }
 
     let action = get_deployment_action(&opts)?;

--- a/kvm-compose/kvm-compose/src/snapshot/testbed_snapshot.rs
+++ b/kvm-compose/kvm-compose/src/snapshot/testbed_snapshot.rs
@@ -1,8 +1,10 @@
 use anyhow::Context;
 use chrono::{DateTime, Utc};
 use futures_util::future::try_join_all;
+use tokio::sync::mpsc::Sender;
 use kvm_compose_schemas::kvm_compose_yaml::machines::GuestType;
 use crate::orchestration::{is_main_testbed, OrchestrationCommon, OrchestrationGuestTask, run_testbed_orchestration_command};
+use crate::orchestration::api::OrchestrationLogger;
 use crate::state::{State};
 
 /// This function will create the whole testbed snapshot by preparing all the artefacts of the
@@ -11,6 +13,7 @@ use crate::state::{State};
 pub async fn run_testbed_snapshot_action(
     state: &State,
     common: &OrchestrationCommon,
+    logging_send: &Sender<OrchestrationLogger>,
 ) -> anyhow::Result<()> {
     // turn off guests
     tracing::info!("turning off all guests before continuing...");
@@ -18,7 +21,7 @@ pub async fn run_testbed_snapshot_action(
     for (_, guest_data) in state.testbed_guests.0.iter() {
         match &guest_data.guest_type.guest_type {
             GuestType::Libvirt(libvirt) => {
-                guest_stop_futures.push(libvirt.destroy_action(common.clone(), guest_data.clone()));
+                guest_stop_futures.push(libvirt.destroy_action(common.clone(), guest_data.clone(), logging_send));
             }
             GuestType::Docker(_) => {}
             GuestType::Android(_) => {
@@ -37,7 +40,7 @@ pub async fn run_testbed_snapshot_action(
                     // place remote images back into the artefacts folder, this will overwrite
                     // the original images but we want to preserve state of the current guest
                     // images
-                    pull_image_futures.push(libvirt.pull_image_action(common.clone(), guest_data.clone()));
+                    pull_image_futures.push(libvirt.pull_image_action(common.clone(), guest_data.clone(), logging_send));
                 }
             }
             GuestType::Docker(_) => {
@@ -56,7 +59,7 @@ pub async fn run_testbed_snapshot_action(
     for (_, guest_data) in state.testbed_guests.0.iter() {
         match &guest_data.guest_type.guest_type {
             GuestType::Libvirt(libvirt) => {
-                guest_start_futures.push(libvirt.create_action(common.clone(), guest_data.clone()));
+                guest_start_futures.push(libvirt.create_action(common.clone(), guest_data.clone(), logging_send));
             }
             GuestType::Docker(_) => {}
             GuestType::Android(_) => {

--- a/kvm-compose/kvm-compose/src/state/orchestration_tasks/generate_artefacts.rs
+++ b/kvm-compose/kvm-compose/src/state/orchestration_tasks/generate_artefacts.rs
@@ -15,6 +15,7 @@ use crate::components::helpers::cloud_init::{create_meta_data, create_network_co
 use crate::components::helpers::xml::render_libvirt_domain_xml;
 use crate::orchestration::{OrchestrationCommon, run_testbed_orchestration_command};
 use crate::state::{State, StateTestbedGuest};
+use crate::state::orchestration_tasks::parse_path_with_deployment_config;
 
 /// This is the generate artefacts version for State rather than Logical testbed
 pub async fn generate_artefacts(
@@ -498,6 +499,10 @@ async fn cloud_init_setup(
                 None => {}
                 Some(context) => {
                     let context_dest = PathBuf::from(format!("{}/context.tar", &project_artefacts_folder));
+
+                    // the context folder given, if relative, must be made absolute
+                    let context = parse_path_with_deployment_config(context, common)?;
+
                     serialisation::tar_cf(&context_dest, &context).await?;
                     cloud_init_inputs.push(context_dest);
                 }

--- a/kvm-compose/kvm-compose/src/state/orchestration_tasks/guests.rs
+++ b/kvm-compose/kvm-compose/src/state/orchestration_tasks/guests.rs
@@ -410,11 +410,12 @@ impl OrchestrationGuestTask for ConfigLibvirtMachine {
                 if let Some(script) = setup_script {
                     tracing::info!("running setup script on guest {}", &machine_config.guest_type.name);
 
-                    logging_sender.send(OrchestrationLogger::info("Waiting until guest is up before continuing".to_string())).await?;
+                    logging_sender.send(OrchestrationLogger::info(format!("Waiting until guest {guest_name} is up before continuing"))).await?;
+
                     wait_for_libvirt_guest_to_be_up(&common, &machine_config, vec!["ls"], logging_sender).await?;
                     let local_script_path = parse_path_with_deployment_config(script, &common)?;
 
-                    logging_sender.send(OrchestrationLogger::info(format!("Pushing {local_script_path:?}"))).await?;
+                    logging_sender.send(OrchestrationLogger::info(format!("Pushing {local_script_path:?} to {guest_name}"))).await?;
                     libvirt::push(
                         &ExecCmdFileTransfer {
                             source_path: local_script_path.clone(),
@@ -425,9 +426,9 @@ impl OrchestrationGuestTask for ConfigLibvirtMachine {
                         &common,
                         logging_sender,
                     ).await?;
-                    logging_sender.send(OrchestrationLogger::info(format!("Pushed {local_script_path:?}"))).await?;
+                    logging_sender.send(OrchestrationLogger::info(format!("Pushed {local_script_path:?} to {guest_name}"))).await?;
 
-                    logging_sender.send(OrchestrationLogger::info("Running setup script".to_string())).await?;
+                    logging_sender.send(OrchestrationLogger::info(format!("Running setup script on {guest_name}"))).await?;
 
                     let script_file_name = {
                         match local_script_path.file_name() {
@@ -500,7 +501,7 @@ impl OrchestrationGuestTask for ConfigLibvirtMachine {
                     let end_time = start_time + Duration::from_secs(*setup_script_timeout_s as u64);
                     loop {
                         if Instant::now() > end_time {
-                            logging_sender.send(OrchestrationLogger::error("Setup script still running but timeout exceeded, continuing without fail".to_string())).await?;
+                            logging_sender.send(OrchestrationLogger::error(format!("Setup script still running on {guest_name} but timeout exceeded, continuing without fail"))).await?;
                             break;
                         }
 
@@ -520,7 +521,7 @@ impl OrchestrationGuestTask for ConfigLibvirtMachine {
 
                         // if non-zero exit code, then pid finished
                         if exit_code != 0 {
-                            logging_sender.send(OrchestrationLogger::info("Setup script finished running".to_string())).await?;
+                            logging_sender.send(OrchestrationLogger::info(format!("Setup script finished running on {guest_name}"))).await?;
                             // check what the exit code was
                             let (_, wait_exit_code) = libvirt::shell_command(
                                 vec!["wait", pid],
@@ -533,9 +534,9 @@ impl OrchestrationGuestTask for ConfigLibvirtMachine {
                                 false,
                             ).await?;
                             if wait_exit_code == 0 {
-                                logging_sender.send(OrchestrationLogger::info("Setup script was successful".to_string())).await?;
+                                logging_sender.send(OrchestrationLogger::info(format!("Setup script was successful on {guest_name}"))).await?;
                             } else {
-                                logging_sender.send(OrchestrationLogger::error(format!("Setup script failed with {wait_exit_code} exit code, will continue"))).await?;
+                                logging_sender.send(OrchestrationLogger::error(format!("Setup script failed on {guest_name} with {wait_exit_code} exit code, will continue"))).await?;
                             }
                             break;
                         }
@@ -548,7 +549,7 @@ impl OrchestrationGuestTask for ConfigLibvirtMachine {
                         if command_duration < desired_interval {
                             let sleep_duration = desired_interval - command_duration;
                             let current_total_time = Instant::now().duration_since(start_time);
-                            logging_sender.send(OrchestrationLogger::info(format!("Command not finished running, waiting for another {sleep_duration:?} before checking again, total loop time ({current_total_time:?}s)"))).await?;
+                            logging_sender.send(OrchestrationLogger::info(format!("Command not finished running on {guest_name}, waiting for another {sleep_duration:?} before checking again, total loop time ({current_total_time:?}s)"))).await?;
                             tokio::time::sleep(sleep_duration).await;
                         }
                     }
@@ -585,11 +586,11 @@ impl OrchestrationGuestTask for ConfigLibvirtMachine {
                 if let Some(script) = run_script {
                     tracing::info!("running setup script on guest {}", &machine_config.guest_type.name);
 
-                    logging_sender.send(OrchestrationLogger::info("Waiting until guest is up before continuing".to_string())).await?;
+                    logging_sender.send(OrchestrationLogger::info(format!("Waiting until guest {guest_name} is up before continuing"))).await?;
                     wait_for_libvirt_guest_to_be_up(&common, &machine_config, vec!["ls"], logging_sender).await?;
                     let local_script_path = parse_path_with_deployment_config(script, &common)?;
 
-                    logging_sender.send(OrchestrationLogger::info(format!("Pushing {local_script_path:?}"))).await?;
+                    logging_sender.send(OrchestrationLogger::info(format!("Pushing {local_script_path:?} to {guest_name}"))).await?;
                     libvirt::push(
                         &ExecCmdFileTransfer {
                             source_path: local_script_path.clone(),
@@ -600,9 +601,9 @@ impl OrchestrationGuestTask for ConfigLibvirtMachine {
                         &common,
                         logging_sender,
                     ).await?;
-                    logging_sender.send(OrchestrationLogger::info(format!("Pushed {local_script_path:?}"))).await?;
+                    logging_sender.send(OrchestrationLogger::info(format!("Pushed {local_script_path:?} to {guest_name}"))).await?;
 
-                    logging_sender.send(OrchestrationLogger::info("Executing run script".to_string())).await?;
+                    logging_sender.send(OrchestrationLogger::info(format!("Executing run script on {guest_name}"))).await?;
 
                     let script_file_name = {
                         match local_script_path.file_name() {
@@ -1407,10 +1408,11 @@ impl OrchestrationGuestTask for ConfigAVDMachine {
         machine_config: StateTestbedGuest,
         logging_sender: &Sender<OrchestrationLogger>,
     ) -> anyhow::Result<()> {
+        let guest_name = format!("{}-{}", &common.project_name, &machine_config.guest_type.name);
         match &self.avd_type {
             AVDGuestOptions::Avd { setup_script, .. } => {
                 if let Some(script) = setup_script {
-                    logging_sender.send(OrchestrationLogger::info("Waiting until guest is up before continuing".to_string())).await?;
+                    logging_sender.send(OrchestrationLogger::info(format!("Waiting until guest {guest_name} is up before continuing"))).await?;
                     wait_for_android_guest_to_be_up(
                         &common,
                         &machine_config,
@@ -1430,9 +1432,9 @@ impl OrchestrationGuestTask for ConfigAVDMachine {
                         .await?;
 
                     if run_setup_script.status.success() {
-                        logging_sender.send(OrchestrationLogger::info("Setup script ran successfully".to_string())).await?;
+                        logging_sender.send(OrchestrationLogger::info(format!("Setup script ran successfully for {guest_name}"))).await?;
                     } else {
-                        logging_sender.send(OrchestrationLogger::error("Setup script did not run successfully, continuing".to_string())).await?;
+                        logging_sender.send(OrchestrationLogger::error(format!("Setup script did not run successfully for {guest_name}, continuing"))).await?;
                     }
 
                 }
@@ -1449,10 +1451,11 @@ impl OrchestrationGuestTask for ConfigAVDMachine {
         machine_config: StateTestbedGuest,
         logging_sender: &Sender<OrchestrationLogger>,
     ) -> anyhow::Result<()> {
+        let guest_name = format!("{}-{}", &common.project_name, &machine_config.guest_type.name);
         match &self.avd_type {
             AVDGuestOptions::Avd { run_script, .. } => {
                 if let Some(script) = run_script {
-                    logging_sender.send(OrchestrationLogger::info("Waiting until guest is up before continuing".to_string())).await?;
+                    logging_sender.send(OrchestrationLogger::info(format!("Waiting until guest {guest_name} is up before continuing"))).await?;
                     wait_for_android_guest_to_be_up(
                         &common,
                         &machine_config,
@@ -1470,9 +1473,9 @@ impl OrchestrationGuestTask for ConfigAVDMachine {
                         .await?;
 
                     if run_setup_script.status.success() {
-                        logging_sender.send(OrchestrationLogger::info("Run script ran successfully".to_string())).await?;
+                        logging_sender.send(OrchestrationLogger::info(format!("Setup script ran successfully for {guest_name}"))).await?;
                     } else {
-                        logging_sender.send(OrchestrationLogger::error("Run script did not run successfully, continuing".to_string())).await?;
+                        logging_sender.send(OrchestrationLogger::error(format!("Setup script did not run successfully for {guest_name}, continuing"))).await?;
                     }
 
                 }

--- a/kvm-compose/kvm-compose/src/state/orchestration_tasks/guests.rs
+++ b/kvm-compose/kvm-compose/src/state/orchestration_tasks/guests.rs
@@ -439,16 +439,37 @@ impl OrchestrationGuestTask for ConfigLibvirtMachine {
                     let script_file_name = script_file_name
                         .context("Converting script name into a string")?;
 
+                    // remove any pre-existing setup flag if it exists
+                    let (_, _) = libvirt::shell_command(
+                        vec!["rm", "SETUP_SCRIPT_COMPLETE.txt"],
+                        5000,
+                        &machine_config,
+                        &guest_name,
+                        &common,
+                        logging_sender,
+                        true,
+                        true,
+                    ).await?;
+                    let (_, _) = libvirt::shell_command(
+                        vec!["rm", "SETUP_SCRIPT_FAILED.txt"],
+                        5000,
+                        &machine_config,
+                        &guest_name,
+                        &common,
+                        logging_sender,
+                        true,
+                        true,
+                    ).await?;
+
                     // run the setup script inthe background
                     let (res_str, _) = libvirt::shell_command(
                         // IMPORTANT - we run the script in the background, and also write a complete
                         //  flag once it is done, which we will look for below to signal the command completed
                         vec!["(",
-                             "rm", "SETUP_SCRIPT_COMPLETE.txt", "||", // remove any existing complete flag
-                             "sudo", "bash", format!("/tmp/{script_file_name}").as_str(), "&&",
+                             "sudo", "bash", format!("/tmp/{script_file_name}").as_str(), ">", "setup.log", "&&",
                              "touch", "SETUP_SCRIPT_COMPLETE.txt", // write a complete flag if success
                              "||", "touch", "SETUP_SCRIPT_FAILED.txt", // write fail flag if fail
-                             ")", ">/dev/null 2>&1", "&", "echo", "$! "], // send the background and print PID
+                             ")", "&", "echo", "$! "], // send the background and print PID
                         5000,
                         &machine_config,
                         &guest_name,

--- a/kvm-compose/kvm-compose/src/state/orchestration_tasks/guests.rs
+++ b/kvm-compose/kvm-compose/src/state/orchestration_tasks/guests.rs
@@ -411,6 +411,7 @@ impl OrchestrationGuestTask for ConfigLibvirtMachine {
 
                     // TODO - push file to guest using console mechanism
 
+                    logging_sender.send(OrchestrationLogger::info("Waiting until guest is up before continuing".to_string())).await?;
                     wait_for_guest_to_be_up(&common, &machine_config, vec!["ls"], logging_sender).await?;
                     let local_script_path = parse_path_with_deployment_config(script, &common)?;
 
@@ -448,9 +449,17 @@ impl OrchestrationGuestTask for ConfigLibvirtMachine {
                         logging_sender,
                         true,
                     ).await?;
-                    logging_sender.send(OrchestrationLogger::info(format!("Script finished running with exit code {exit_code:?}"))).await?;
+
+                    let script_output = format!("Script output:\n{res_str:?}");
+                    let script_exit_code = format!("Script finished running with exit code {exit_code:?}");
                     if exit_code != 0 {
-                        logging_sender.send(OrchestrationLogger::error(format!("Script output:\n{res_str:?}"))).await?;
+                        logging_sender.send(OrchestrationLogger::error(script_exit_code)).await?;
+                        logging_sender.send(OrchestrationLogger::error(script_output)).await?;
+                        // we fail the run here, since we assume that it was necessary to work
+                        bail!("Setup script execution failed");
+                    } else {
+                        logging_sender.send(OrchestrationLogger::info(script_exit_code)).await?;
+                        logging_sender.send(OrchestrationLogger::info(script_output)).await?;
                     }
                 }
             }

--- a/kvm-compose/kvm-compose/src/state/orchestration_tasks/guests.rs
+++ b/kvm-compose/kvm-compose/src/state/orchestration_tasks/guests.rs
@@ -8,11 +8,12 @@ use glob::{glob};
 use nix::unistd::{Gid, Uid};
 use tokio::sync::mpsc::Sender;
 use kvm_compose_schemas::exec::ExecCmdFileTransfer;
-use kvm_compose_schemas::kvm_compose_yaml::machines::avd::ConfigAVDMachine;
+use kvm_compose_schemas::kvm_compose_yaml::machines::avd::{AVDGuestOptions, ConfigAVDMachine};
 use kvm_compose_schemas::kvm_compose_yaml::machines::docker::ConfigDockerMachine;
 use kvm_compose_schemas::kvm_compose_yaml::machines::GuestType;
 use kvm_compose_schemas::kvm_compose_yaml::machines::libvirt::{ConfigLibvirtMachine, LibvirtGuestOptions};
 use crate::components::get_guest_interface_name;
+use crate::exec;
 use crate::exec::{libvirt};
 use crate::orchestration::{is_main_testbed, OrchestrationCommon, OrchestrationGuestTask, run_testbed_orchestration_command, run_testbed_orchestration_command_allow_fail};
 use crate::orchestration::api::OrchestrationLogger;
@@ -410,7 +411,7 @@ impl OrchestrationGuestTask for ConfigLibvirtMachine {
                     tracing::info!("running setup script on guest {}", &machine_config.guest_type.name);
 
                     logging_sender.send(OrchestrationLogger::info("Waiting until guest is up before continuing".to_string())).await?;
-                    wait_for_guest_to_be_up(&common, &machine_config, vec!["ls"], logging_sender).await?;
+                    wait_for_libvirt_guest_to_be_up(&common, &machine_config, vec!["ls"], logging_sender).await?;
                     let local_script_path = parse_path_with_deployment_config(script, &common)?;
 
                     logging_sender.send(OrchestrationLogger::info(format!("Pushing {local_script_path:?}"))).await?;
@@ -585,7 +586,7 @@ impl OrchestrationGuestTask for ConfigLibvirtMachine {
                     tracing::info!("running setup script on guest {}", &machine_config.guest_type.name);
 
                     logging_sender.send(OrchestrationLogger::info("Waiting until guest is up before continuing".to_string())).await?;
-                    wait_for_guest_to_be_up(&common, &machine_config, vec!["ls"], logging_sender).await?;
+                    wait_for_libvirt_guest_to_be_up(&common, &machine_config, vec!["ls"], logging_sender).await?;
                     let local_script_path = parse_path_with_deployment_config(script, &common)?;
 
                     logging_sender.send(OrchestrationLogger::info(format!("Pushing {local_script_path:?}"))).await?;
@@ -1402,20 +1403,84 @@ impl OrchestrationGuestTask for ConfigAVDMachine {
 
     async fn setup_action(
         &self,
-        _common: OrchestrationCommon,
-        _machine_config: StateTestbedGuest,
-        _logging_sender: &Sender<OrchestrationLogger>,
+        common: OrchestrationCommon,
+        machine_config: StateTestbedGuest,
+        logging_sender: &Sender<OrchestrationLogger>,
     ) -> anyhow::Result<()> {
-        todo!()
+        match &self.avd_type {
+            AVDGuestOptions::Avd { setup_script, .. } => {
+                if let Some(script) = setup_script {
+                    logging_sender.send(OrchestrationLogger::info("Waiting until guest is up before continuing".to_string())).await?;
+                    wait_for_android_guest_to_be_up(
+                        &common,
+                        &machine_config,
+                        &logging_sender,
+                    ).await?;
+
+                    let local_script_path = parse_path_with_deployment_config(script, &common)?;
+
+                    // now that the guest is up, we can run the setup script that has been provided
+                    // which can run arbitrary things but at least runs when the guest is available
+
+                    // we will run this from the project working directory
+                    let run_setup_script = tokio::process::Command::new("bash")
+                        .arg(local_script_path)
+                        .current_dir(common.project_working_dir)
+                        .output()
+                        .await?;
+
+                    if run_setup_script.status.success() {
+                        logging_sender.send(OrchestrationLogger::info("Setup script ran successfully".to_string())).await?;
+                    } else {
+                        logging_sender.send(OrchestrationLogger::error("Setup script did not run successfully, continuing".to_string())).await?;
+                    }
+
+                }
+            }
+            AVDGuestOptions::ExistingAvd { .. } => {}
+        }
+
+        Ok(())
     }
 
     async fn run_action(
         &self,
-        _common: OrchestrationCommon,
-        _machine_config: StateTestbedGuest,
-        _logging_sender: &Sender<OrchestrationLogger>,
+        common: OrchestrationCommon,
+        machine_config: StateTestbedGuest,
+        logging_sender: &Sender<OrchestrationLogger>,
     ) -> anyhow::Result<()> {
-        todo!()
+        match &self.avd_type {
+            AVDGuestOptions::Avd { run_script, .. } => {
+                if let Some(script) = run_script {
+                    logging_sender.send(OrchestrationLogger::info("Waiting until guest is up before continuing".to_string())).await?;
+                    wait_for_android_guest_to_be_up(
+                        &common,
+                        &machine_config,
+                        &logging_sender,
+                    ).await?;
+
+                    let local_script_path = parse_path_with_deployment_config(script, &common)?;
+
+                    // we will run this from the project working directory
+                    let run_setup_script = tokio::process::Command::new("bash")
+                        .arg(local_script_path)
+                        .arg("&")
+                        .current_dir(common.project_working_dir)
+                        .output()
+                        .await?;
+
+                    if run_setup_script.status.success() {
+                        logging_sender.send(OrchestrationLogger::info("Run script ran successfully".to_string())).await?;
+                    } else {
+                        logging_sender.send(OrchestrationLogger::error("Run script did not run successfully, continuing".to_string())).await?;
+                    }
+
+                }
+            }
+            AVDGuestOptions::ExistingAvd { .. } => {}
+        }
+
+        Ok(())
     }
 
     async fn destroy_action(
@@ -1496,7 +1561,7 @@ fn get_xml_path(
     format!("{local_image_parent_path}/{domain_xml_name}")
 }
 
-async fn wait_for_guest_to_be_up(
+async fn wait_for_libvirt_guest_to_be_up(
     common: &OrchestrationCommon,
     machine_config: &StateTestbedGuest,
     command: Vec<&str>,
@@ -1521,6 +1586,42 @@ async fn wait_for_guest_to_be_up(
             logging_sender,
             true,
             false,
+        ).await;
+
+        if counter > attempt_limit && poll_res.is_err() {
+            // we waited 12 times with a wait, the command didnt work so this has failed
+            bail!("could not connect to guest {}-{} to check if it is up, might not have booted successfully", &common.project_name, &machine_config.guest_type.name);
+        } else if poll_res.is_ok() {
+            // successful connection, return ok
+            break;
+        }
+        tracing::info!("attempt {counter}/{attempt_limit} guest {guest_name} not up yet, waiting 5s and trying again");
+        counter += 1;
+        tokio::time::sleep(Duration::from_secs(wait_time_in_seconds)).await;
+
+    }
+    Ok(())
+}
+
+async fn wait_for_android_guest_to_be_up(
+    common: &OrchestrationCommon,
+    machine_config: &StateTestbedGuest,
+    logging_sender: &Sender<OrchestrationLogger>,
+) -> anyhow::Result<()> {
+    // we will poll the guest with the given command in a loop, for a number of attempts in a time
+    // limit
+    let attempt_limit = 24;
+    let wait_time_in_seconds = 5;
+    let guest_name = &machine_config.guest_type.name;
+    let namespace = format!("{}-{}-nmspc", &common.project_name, guest_name);
+    let mut counter = 0;
+    loop {
+        tracing::info!("trying to poll guest {guest_name} to see if it is up ...");
+
+        let poll_res = exec::android::adb_command(
+            &namespace,
+            &vec!["ls".to_string(), ".".to_string()],
+            logging_sender,
         ).await;
 
         if counter > attempt_limit && poll_res.is_err() {

--- a/kvm-compose/kvm-compose/src/state/orchestration_tasks/guests.rs
+++ b/kvm-compose/kvm-compose/src/state/orchestration_tasks/guests.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 use std::path::PathBuf;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use anyhow::{anyhow, bail, Context};
 use async_trait::async_trait;
 use futures_util::future::{try_join_all};
@@ -405,7 +405,7 @@ impl OrchestrationGuestTask for ConfigLibvirtMachine {
         // run any setup
         let guest_name = format!("{}-{}", &common.project_name, &machine_config.guest_type.name);
         match &self.libvirt_type {
-            LibvirtGuestOptions::CloudImage { setup_script, .. } => {
+            LibvirtGuestOptions::CloudImage { setup_script, setup_script_timeout_s, .. } => {
                 if let Some(script) = setup_script {
                     tracing::info!("running setup script on guest {}", &machine_config.guest_type.name);
 
@@ -440,27 +440,110 @@ impl OrchestrationGuestTask for ConfigLibvirtMachine {
                     };
                     let script_file_name = script_file_name
                         .context("Converting script name into a string")?;
-                    let (res_str, exit_code) = libvirt::shell_command(
-                        vec!["sudo", "bash", format!("/tmp/{script_file_name}").as_str()],
+
+                    // run the setup script inthe background
+                    let (res_str, _) = libvirt::shell_command(
+                        // IMPORTANT - we run the script in the background, and also write a complete
+                        //  flag once it is done, which we will look for below to signal the command completed
+                        vec!["(",
+                             "rm", "SETUP_SCRIPT_COMPLETE.txt", "||", // remove any existing complete flag
+                             "sudo", "bash", format!("/tmp/{script_file_name}").as_str(), "&&",
+                             "touch", "SETUP_SCRIPT_COMPLETE.txt", // write a complete flag if success
+                             "||", "touch", "SETUP_SCRIPT_FAILED.txt", // write fail flag if fail
+                             ")", ">/dev/null 2>&1", "&", "echo", "$! "], // send the background and print PID
                         5000,
                         &machine_config,
                         &guest_name,
                         &common,
                         logging_sender,
                         true,
+                        false,
                     ).await?;
 
-                    let script_output = format!("Script output:\n{res_str:?}");
-                    let script_exit_code = format!("Script finished running with exit code {exit_code:?}");
-                    if exit_code != 0 {
-                        logging_sender.send(OrchestrationLogger::error(script_exit_code)).await?;
-                        logging_sender.send(OrchestrationLogger::error(script_output)).await?;
-                        // we fail the run here, since we assume that it was necessary to work
-                        bail!("Setup script execution failed");
-                    } else {
-                        logging_sender.send(OrchestrationLogger::info(script_exit_code)).await?;
-                        logging_sender.send(OrchestrationLogger::info(script_output)).await?;
+                    // get the pid from the return text, should be the last string
+                    let return_text= res_str.split("\n").collect::<Vec<_>>();
+                    let pid = return_text[return_text.len()-1];
+
+                    let loop_interval = 5;
+                    logging_sender.send(OrchestrationLogger::info(
+                        format!("Got PID ({pid}), waiting for up to ({setup_script_timeout_s}s) \
+                        with an interval check of ({loop_interval}s) before aborting")
+                    )).await?;
+
+                    // with the PID, we can check for it for the given setup script timeout set by
+                    // the user or default timeout setup_script_timeout_s
+                    // if kill -0 pid returns 0 it is still running, if errors then it has finished
+
+                    // in the loop, we wait every 5 seconds to check, but factor in the time it takes
+                    // to run the command
+                    let start_time = Instant::now();
+                    let end_time = start_time + Duration::from_secs(*setup_script_timeout_s as u64);
+                    loop {
+                        if Instant::now() > end_time {
+                            logging_sender.send(OrchestrationLogger::error("Setup script still running but timeout exceeded, continuing without fail".to_string())).await?;
+                            break;
+                        }
+
+                        let loop_start_time = Instant::now();
+
+                        // check if pid is still running
+                        let (_, exit_code) = libvirt::shell_command(
+                            vec!["kill", "-0", pid],
+                            5000,
+                            &machine_config,
+                            &guest_name,
+                            &common,
+                            logging_sender,
+                            true,
+                            false,
+                        ).await?;
+
+                        // if non-zero exit code, then pid finished
+                        if exit_code != 0 {
+                            logging_sender.send(OrchestrationLogger::info("Setup script finished running".to_string())).await?;
+                            // check what the exit code was
+                            let (_, wait_exit_code) = libvirt::shell_command(
+                                vec!["wait", pid],
+                                5000,
+                                &machine_config,
+                                &guest_name,
+                                &common,
+                                logging_sender,
+                                true,
+                                false,
+                            ).await?;
+                            if wait_exit_code == 0 {
+                                logging_sender.send(OrchestrationLogger::info("Setup script was successful".to_string())).await?;
+                            } else {
+                                logging_sender.send(OrchestrationLogger::error(format!("Setup script failed with {wait_exit_code} exit code, will continue"))).await?;
+                            }
+                            break;
+                        }
+
+                        let command_end_time = Instant::now();
+                        let command_duration = command_end_time.duration_since(loop_start_time);
+
+                        // sleep the required amount of time to make it up to the check interval
+                        let desired_interval = Duration::from_secs(loop_interval);
+                        if command_duration < desired_interval {
+                            let sleep_duration = desired_interval - command_duration;
+                            let current_total_time = Instant::now().duration_since(start_time);
+                            logging_sender.send(OrchestrationLogger::info(format!("Command not finished running, waiting for another {sleep_duration:?} before checking again, total loop time ({current_total_time:?}s)"))).await?;
+                            tokio::time::sleep(sleep_duration).await;
+                        }
                     }
+
+                    // let script_output = format!("Script output:\n{res_str:?}");
+                    // let script_exit_code = format!("Script finished running with exit code {exit_code:?}");
+                    // if exit_code != 0 {
+                    //     logging_sender.send(OrchestrationLogger::error(script_exit_code)).await?;
+                    //     logging_sender.send(OrchestrationLogger::error(script_output)).await?;
+                    //     // we fail the run here, since we assume that it was necessary to work
+                    //     bail!("Setup script execution failed");
+                    // } else {
+                    //     logging_sender.send(OrchestrationLogger::info(script_exit_code)).await?;
+                    //     logging_sender.send(OrchestrationLogger::info(script_output)).await?;
+                    // }
                 }
             }
             LibvirtGuestOptions::ExistingDisk { .. } => {}
@@ -1362,6 +1445,7 @@ async fn wait_for_guest_to_be_up(
             common,
             logging_sender,
             true,
+            false,
         ).await;
 
         if counter > attempt_limit && poll_res.is_err() {

--- a/kvm-compose/kvm-compose/src/state/orchestration_tasks/guests.rs
+++ b/kvm-compose/kvm-compose/src/state/orchestration_tasks/guests.rs
@@ -6,20 +6,29 @@ use async_trait::async_trait;
 use futures_util::future::{try_join_all};
 use glob::{glob};
 use nix::unistd::{Gid, Uid};
+use tokio::sync::mpsc::Sender;
+use kvm_compose_schemas::exec::ExecCmdFileTransfer;
 use kvm_compose_schemas::kvm_compose_yaml::machines::avd::ConfigAVDMachine;
 use kvm_compose_schemas::kvm_compose_yaml::machines::docker::ConfigDockerMachine;
 use kvm_compose_schemas::kvm_compose_yaml::machines::GuestType;
 use kvm_compose_schemas::kvm_compose_yaml::machines::libvirt::{ConfigLibvirtMachine, LibvirtGuestOptions};
 use crate::components::get_guest_interface_name;
+use crate::exec::{libvirt};
 use crate::orchestration::{is_main_testbed, OrchestrationCommon, OrchestrationGuestTask, run_testbed_orchestration_command, run_testbed_orchestration_command_allow_fail};
+use crate::orchestration::api::OrchestrationLogger;
 use crate::orchestration::ssh::SSHClient;
 use crate::ovn::components::logical_switch_port::LogicalSwitchPortType;
 use crate::state::{State, StateNetwork, StateTestbedGuest, StateTestbedGuestList};
-
+use crate::state::orchestration_tasks::parse_path_with_deployment_config;
 
 #[async_trait]
 impl OrchestrationGuestTask for ConfigLibvirtMachine {
-    async fn setup_image_action(&self, common: OrchestrationCommon, machine_config: StateTestbedGuest) -> anyhow::Result<()> {
+    async fn setup_image_action(
+        &self,
+        common: OrchestrationCommon,
+        machine_config: StateTestbedGuest,
+        _logging_sender: &Sender<OrchestrationLogger>,
+    ) -> anyhow::Result<()> {
         // we need to make a distinction between a backing image, a clone of a backing image and
         // a normal libvirt image that should be deployed
 
@@ -29,7 +38,7 @@ impl OrchestrationGuestTask for ConfigLibvirtMachine {
             // if the clone has a shared_setup script, then boot, run script then turn it off
             // otherwise just create the image
             // the backing image guest definition will have a scaling option
-            if let Some(shared_setup) = self.scaling.clone().context("getting scaling config for libvirt guest")?.shared_setup {
+            if let Some(_shared_setup) = self.scaling.clone().context("getting scaling config for libvirt guest")?.shared_setup {
                 tracing::info!("setting up backing image guest {} as it has a shared setup script", &guest_name);
                 // there is a shared setup script
                 // artefact generation has already created a domain xml with the interface set to
@@ -38,32 +47,9 @@ impl OrchestrationGuestTask for ConfigLibvirtMachine {
                 tracing::info!("starting base backing image guest {guest_name} to run share setup script");
                 match self.libvirt_type {
                     LibvirtGuestOptions::CloudImage { .. } => {
-                        // cloud images will have the testbed guest public key pushed so we can
-                        // use ssh
-                        self.create_action(common.clone(), machine_config.clone()).await?;
-                        // wait for guest to be up
-                        tracing::info!("waiting for guest {guest_name} to start");
-                        // TODO - observed the guest's ssh server may not start, why? and cant restart manually
-                        wait_for_guest_to_be_up(&common, &machine_config, vec!["ls"]).await?;
-                        tracing::info!("running shared setup script on guest {guest_name}");
-                        let shared_setup_script = shared_setup.to_str().context("getting shared setup script path")?;
-                        let path_to_shared_setup_script = format!("{}/{}", &common.project_working_dir.to_str().context("getting project working dir")?, shared_setup_script);
-                        SSHClient::push_file_to_guest(
-                            &common,
-                            &path_to_shared_setup_script,
-                            &"/tmp".to_string(),
-                            &self.username.as_ref().unwrap(),
-                            &guest_name,
-                        ).await?;
-                        SSHClient::run_guest_command(
-                            &common,
-                            vec!["sudo", "bash", format!("/tmp/{shared_setup_script}").as_str()],
-                            &machine_config,
-                            false,
-                        ).await?;
-                        // turn off guest
-                        tracing::info!("turning off guest {guest_name} now shared setup script has finished running");
-                        self.destroy_action(common.clone(), machine_config).await?;
+                        // TODO - this needs to be reworked to use exec cmd, no more SSHClient ..
+                        //  see code that was here previously for guidance on re-implementing
+                        unimplemented!();
                     }
                     LibvirtGuestOptions::ExistingDisk { .. } => unimplemented!(),
                     LibvirtGuestOptions::IsoGuest { .. } => unimplemented!(),
@@ -134,7 +120,12 @@ impl OrchestrationGuestTask for ConfigLibvirtMachine {
         Ok(())
     }
 
-    async fn push_image_action(&self, common: OrchestrationCommon, machine_config: StateTestbedGuest) -> anyhow::Result<()> {
+    async fn push_image_action(
+        &self,
+        common: OrchestrationCommon,
+        machine_config: StateTestbedGuest,
+        _logging_sender: &Sender<OrchestrationLogger>,
+    ) -> anyhow::Result<()> {
 
         let mut futures = Vec::new();
 
@@ -223,7 +214,12 @@ impl OrchestrationGuestTask for ConfigLibvirtMachine {
         Ok(())
     }
 
-    async fn pull_image_action(&self, common: OrchestrationCommon, machine_config: StateTestbedGuest) -> anyhow::Result<()> {
+    async fn pull_image_action(
+        &self,
+        common: OrchestrationCommon,
+        machine_config: StateTestbedGuest,
+        _logging_sender: &Sender<OrchestrationLogger>,
+    ) -> anyhow::Result<()> {
         let target_testbed = machine_config.testbed_host.as_ref().unwrap();
         let guest_name = format!("{}", &machine_config.guest_type.name);
         if is_main_testbed(&common, target_testbed) {
@@ -249,7 +245,13 @@ impl OrchestrationGuestTask for ConfigLibvirtMachine {
         }
     }
 
-    async fn rebase_image_action(&self, common: OrchestrationCommon, machine_config: StateTestbedGuest, guest_list: StateTestbedGuestList) -> anyhow::Result<()> {
+    async fn rebase_image_action(
+        &self,
+        common: OrchestrationCommon,
+        machine_config: StateTestbedGuest,
+        guest_list: StateTestbedGuestList,
+        _logging_sender: &Sender<OrchestrationLogger>,
+    ) -> anyhow::Result<()> {
         tracing::info!("rebasing image for guest {}", &machine_config.guest_type.name);
         let target_testbed = machine_config.testbed_host.as_ref().unwrap();
         if is_main_testbed(&common, target_testbed) {
@@ -282,7 +284,12 @@ impl OrchestrationGuestTask for ConfigLibvirtMachine {
         Ok(())
     }
 
-    async fn create_action(&self, common: OrchestrationCommon, machine_config: StateTestbedGuest) -> anyhow::Result<()> {
+    async fn create_action(
+        &self,
+        common: OrchestrationCommon,
+        machine_config: StateTestbedGuest,
+        _logging_sender: &Sender<OrchestrationLogger>,
+    ) -> anyhow::Result<()> {
         tracing::info!("deploying guest {}", &machine_config.guest_type.name);
         let testbed_host = machine_config.testbed_host.as_ref().unwrap();
         let project_path = if is_main_testbed(&common, testbed_host) {
@@ -389,28 +396,62 @@ impl OrchestrationGuestTask for ConfigLibvirtMachine {
         Ok(())
     }
 
-    async fn setup_action(&self, common: OrchestrationCommon, machine_config: StateTestbedGuest) -> anyhow::Result<()> {
+    async fn setup_action(
+        &self,
+        common: OrchestrationCommon,
+        machine_config: StateTestbedGuest,
+        logging_sender: &Sender<OrchestrationLogger>,
+    ) -> anyhow::Result<()> {
         // run any setup
         let guest_name = format!("{}-{}", &common.project_name, &machine_config.guest_type.name);
         match &self.libvirt_type {
             LibvirtGuestOptions::CloudImage { setup_script, .. } => {
                 if let Some(script) = setup_script {
                     tracing::info!("running setup script on guest {}", &machine_config.guest_type.name);
-                    wait_for_guest_to_be_up(&common, &machine_config, vec!["ls"]).await?;
-                    let local_script_path = script.to_str().unwrap().to_string();
-                    SSHClient::push_file_to_guest(
-                        &common,
-                        &local_script_path,
-                        &"/tmp".to_string(),
-                        &self.username.as_ref().unwrap(),
-                        &guest_name,
-                    ).await?;
-                    SSHClient::run_guest_command(
-                        &common,
-                        vec!["sudo", "bash", format!("/tmp/{local_script_path}").as_str()],
+
+                    // TODO - push file to guest using console mechanism
+
+                    wait_for_guest_to_be_up(&common, &machine_config, vec!["ls"], logging_sender).await?;
+                    let local_script_path = parse_path_with_deployment_config(script, &common)?;
+
+                    logging_sender.send(OrchestrationLogger::info(format!("Pushing {local_script_path:?}"))).await?;
+                    libvirt::push(
+                        &ExecCmdFileTransfer {
+                            source_path: local_script_path.clone(),
+                            target_path: PathBuf::from("/tmp"),
+                        },
                         &machine_config,
-                        false,
+                        &guest_name,
+                        &common,
+                        logging_sender,
                     ).await?;
+                    logging_sender.send(OrchestrationLogger::info(format!("Pushed {local_script_path:?}"))).await?;
+
+                    logging_sender.send(OrchestrationLogger::info("Running setup script".to_string())).await?;
+
+                    let script_file_name = {
+                        match local_script_path.file_name() {
+                            None => bail!("The script path given {local_script_path:?} is not a file, likely a directory."),
+                            Some(os_str) => {
+                                os_str.to_str().map(|s| s.to_string())
+                            }
+                        }
+                    };
+                    let script_file_name = script_file_name
+                        .context("Converting script name into a string")?;
+                    let (res_str, exit_code) = libvirt::shell_command(
+                        vec!["sudo", "bash", format!("/tmp/{script_file_name}").as_str()],
+                        5000,
+                        &machine_config,
+                        &guest_name,
+                        &common,
+                        logging_sender,
+                        true,
+                    ).await?;
+                    logging_sender.send(OrchestrationLogger::info(format!("Script finished running with exit code {exit_code:?}"))).await?;
+                    if exit_code != 0 {
+                        logging_sender.send(OrchestrationLogger::error(format!("Script output:\n{res_str:?}"))).await?;
+                    }
                 }
             }
             LibvirtGuestOptions::ExistingDisk { .. } => {}
@@ -419,11 +460,21 @@ impl OrchestrationGuestTask for ConfigLibvirtMachine {
         Ok(())
     }
 
-    async fn run_action(&self, _common: OrchestrationCommon, _machine_config: StateTestbedGuest) -> anyhow::Result<()> {
+    async fn run_action(
+        &self,
+        _common: OrchestrationCommon,
+        _machine_config: StateTestbedGuest,
+        _logging_sender: &Sender<OrchestrationLogger>,
+    ) -> anyhow::Result<()> {
         todo!()
     }
 
-    async fn destroy_action(&self, common: OrchestrationCommon, machine_config: StateTestbedGuest) -> anyhow::Result<()> {
+    async fn destroy_action(
+        &self,
+        common: OrchestrationCommon,
+        machine_config: StateTestbedGuest,
+        _logging_sender: &Sender<OrchestrationLogger>,
+    ) -> anyhow::Result<()> {
         let guest_name = format!("{}-{}", common.project_name, &machine_config.guest_type.name);
         if machine_config.is_golden_image {
             tracing::info!("making sure backing image guest {} is off", &guest_name);
@@ -461,7 +512,12 @@ impl OrchestrationGuestTask for ConfigLibvirtMachine {
         Ok(())
     }
 
-    async fn is_up(&self, common: OrchestrationCommon, machine_config: StateTestbedGuest) -> anyhow::Result<bool> {
+    async fn is_up(
+        &self,
+        common: OrchestrationCommon,
+        machine_config: StateTestbedGuest,
+        _logging_sender: &Sender<OrchestrationLogger>,
+    ) -> anyhow::Result<bool> {
         let testbed_host = machine_config.testbed_host.as_ref().unwrap();
         let guest_name = format!("{}-{}", &common.project_name, &machine_config.guest_type.name);
 
@@ -487,11 +543,21 @@ impl OrchestrationGuestTask for ConfigLibvirtMachine {
 
 #[async_trait]
 impl OrchestrationGuestTask for ConfigDockerMachine {
-    async fn setup_image_action(&self, _common: OrchestrationCommon, _machine_config: StateTestbedGuest) -> anyhow::Result<()> {
+    async fn setup_image_action(
+        &self,
+        _common: OrchestrationCommon,
+        _machine_config: StateTestbedGuest,
+        _logging_sender: &Sender<OrchestrationLogger>,
+    ) -> anyhow::Result<()> {
         todo!()
     }
 
-    async fn push_image_action(&self, common: OrchestrationCommon, machine_config: StateTestbedGuest) -> anyhow::Result<()> {
+    async fn push_image_action(
+        &self,
+        common: OrchestrationCommon,
+        machine_config: StateTestbedGuest,
+        _logging_sender: &Sender<OrchestrationLogger>,
+    ) -> anyhow::Result<()> {
 
         let mut futures = Vec::new();
         let testbed_host = machine_config.testbed_host.as_ref().unwrap();
@@ -539,15 +605,31 @@ impl OrchestrationGuestTask for ConfigDockerMachine {
         Ok(())
     }
 
-    async fn pull_image_action(&self, _common: OrchestrationCommon, _machine_config: StateTestbedGuest) -> anyhow::Result<()> {
+    async fn pull_image_action(
+        &self,
+        _common: OrchestrationCommon,
+        _machine_config: StateTestbedGuest,
+        _logging_sender: &Sender<OrchestrationLogger>,
+    ) -> anyhow::Result<()> {
         todo!()
     }
 
-    async fn rebase_image_action(&self, _common: OrchestrationCommon, _machine_config: StateTestbedGuest, _guest_list: StateTestbedGuestList) -> anyhow::Result<()> {
+    async fn rebase_image_action(
+        &self,
+        _common: OrchestrationCommon,
+        _machine_config: StateTestbedGuest,
+        _guest_list: StateTestbedGuestList,
+        _logging_sender: &Sender<OrchestrationLogger>,
+    ) -> anyhow::Result<()> {
         todo!()
     }
 
-    async fn create_action(&self, common: OrchestrationCommon, machine_config: StateTestbedGuest) -> anyhow::Result<()> {
+    async fn create_action(
+        &self,
+        common: OrchestrationCommon,
+        machine_config: StateTestbedGuest,
+        _logging_sender: &Sender<OrchestrationLogger>,
+    ) -> anyhow::Result<()> {
 
         tracing::info!("deploying guest {}", &machine_config.guest_type.name);
 
@@ -851,15 +933,30 @@ impl OrchestrationGuestTask for ConfigDockerMachine {
         Ok(())
     }
 
-    async fn setup_action(&self, _common: OrchestrationCommon, _machine_config: StateTestbedGuest) -> anyhow::Result<()> {
+    async fn setup_action(
+        &self,
+        _common: OrchestrationCommon,
+        _machine_config: StateTestbedGuest,
+        _logging_sender: &Sender<OrchestrationLogger>,
+    ) -> anyhow::Result<()> {
         todo!()
     }
 
-    async fn run_action(&self, _common: OrchestrationCommon, _machine_config: StateTestbedGuest) -> anyhow::Result<()> {
+    async fn run_action(
+        &self,
+        _common: OrchestrationCommon,
+        _machine_config: StateTestbedGuest,
+        _logging_sender: &Sender<OrchestrationLogger>,
+    ) -> anyhow::Result<()> {
         todo!()
     }
 
-    async fn destroy_action(&self, common: OrchestrationCommon, machine_config: StateTestbedGuest) -> anyhow::Result<()> {
+    async fn destroy_action(
+        &self,
+        common: OrchestrationCommon,
+        machine_config: StateTestbedGuest,
+        _logging_sender: &Sender<OrchestrationLogger>,
+    ) -> anyhow::Result<()> {
         tracing::info!("turning off guest {}", &machine_config.guest_type.name);
         let testbed_host = machine_config.testbed_host.as_ref().unwrap();
         let guest_name = format!("{}-{}", &common.project_name, &machine_config.guest_type.name);
@@ -916,30 +1013,60 @@ impl OrchestrationGuestTask for ConfigDockerMachine {
         Ok(())
     }
 
-    async fn is_up(&self, _common: OrchestrationCommon, _machine_config: StateTestbedGuest) -> anyhow::Result<bool> {
+    async fn is_up(
+        &self,
+        _common: OrchestrationCommon,
+        _machine_config: StateTestbedGuest,
+        _logging_sender: &Sender<OrchestrationLogger>,
+    ) -> anyhow::Result<bool> {
         todo!()
     }
 }
 
 #[async_trait]
 impl OrchestrationGuestTask for ConfigAVDMachine {
-    async fn setup_image_action(&self, _common: OrchestrationCommon, _machine_config: StateTestbedGuest) -> anyhow::Result<()> {
+    async fn setup_image_action(
+        &self, _common: OrchestrationCommon,
+        _machine_config: StateTestbedGuest,
+        _logging_sender: &Sender<OrchestrationLogger>,
+    ) -> anyhow::Result<()> {
         todo!()
     }
 
-    async fn push_image_action(&self, _common: OrchestrationCommon, _machine_config: StateTestbedGuest) -> anyhow::Result<()> {
+    async fn push_image_action(
+        &self,
+        _common: OrchestrationCommon,
+        _machine_config: StateTestbedGuest,
+        _logging_sender: &Sender<OrchestrationLogger>,
+    ) -> anyhow::Result<()> {
         todo!()
     }
 
-    async fn pull_image_action(&self, _common: OrchestrationCommon, _machine_config: StateTestbedGuest) -> anyhow::Result<()> {
+    async fn pull_image_action(
+        &self,
+        _common: OrchestrationCommon,
+        _machine_config: StateTestbedGuest,
+        _logging_sender: &Sender<OrchestrationLogger>,
+    ) -> anyhow::Result<()> {
         todo!()
     }
 
-    async fn rebase_image_action(&self, _common: OrchestrationCommon, _machine_config: StateTestbedGuest, _guest_list: StateTestbedGuestList) -> anyhow::Result<()> {
+    async fn rebase_image_action(
+        &self,
+        _common: OrchestrationCommon,
+        _machine_config: StateTestbedGuest,
+        _guest_list: StateTestbedGuestList,
+        _logging_sender: &Sender<OrchestrationLogger>,
+    ) -> anyhow::Result<()> {
         todo!()
     }
 
-    async fn create_action(&self, common: OrchestrationCommon, machine_config: StateTestbedGuest) -> anyhow::Result<()> {
+    async fn create_action(
+        &self,
+        common: OrchestrationCommon,
+        machine_config: StateTestbedGuest,
+        _logging_sender: &Sender<OrchestrationLogger>,
+    ) -> anyhow::Result<()> {
 
         tracing::info!("deploying guest {}", &machine_config.guest_type.name);
         let testbed_host = machine_config.testbed_host.as_ref().unwrap();
@@ -1106,15 +1233,30 @@ impl OrchestrationGuestTask for ConfigAVDMachine {
         Ok(())
     }
 
-    async fn setup_action(&self, _common: OrchestrationCommon, _machine_config: StateTestbedGuest) -> anyhow::Result<()> {
+    async fn setup_action(
+        &self,
+        _common: OrchestrationCommon,
+        _machine_config: StateTestbedGuest,
+        _logging_sender: &Sender<OrchestrationLogger>,
+    ) -> anyhow::Result<()> {
         todo!()
     }
 
-    async fn run_action(&self, _common: OrchestrationCommon, _machine_config: StateTestbedGuest) -> anyhow::Result<()> {
+    async fn run_action(
+        &self,
+        _common: OrchestrationCommon,
+        _machine_config: StateTestbedGuest,
+        _logging_sender: &Sender<OrchestrationLogger>,
+    ) -> anyhow::Result<()> {
         todo!()
     }
 
-    async fn destroy_action(&self, common: OrchestrationCommon, machine_config: StateTestbedGuest) -> anyhow::Result<()> {
+    async fn destroy_action(
+        &self,
+        common: OrchestrationCommon,
+        machine_config: StateTestbedGuest,
+        _logging_sender: &Sender<OrchestrationLogger>,
+    ) -> anyhow::Result<()> {
         tracing::info!("turning off guest {}", &machine_config.guest_type.name);
         let guest_name = machine_config.guest_type.name;
         let testbed_host = machine_config.testbed_host.as_ref().unwrap();
@@ -1160,7 +1302,12 @@ impl OrchestrationGuestTask for ConfigAVDMachine {
         Ok(())
     }
 
-    async fn is_up(&self, _common: OrchestrationCommon, _machine_config: StateTestbedGuest) -> anyhow::Result<bool> {
+    async fn is_up(
+        &self,
+        _common: OrchestrationCommon,
+        _machine_config: StateTestbedGuest,
+        _logging_sender: &Sender<OrchestrationLogger>,
+    ) -> anyhow::Result<bool> {
         todo!()
     }
 }
@@ -1186,6 +1333,7 @@ async fn wait_for_guest_to_be_up(
     common: &OrchestrationCommon,
     machine_config: &StateTestbedGuest,
     command: Vec<&str>,
+    logging_sender: &Sender<OrchestrationLogger>,
 ) -> anyhow::Result<()> {
     // we will poll the guest with the given command in a loop, for a number of attempts in a time
     // limit
@@ -1195,12 +1343,18 @@ async fn wait_for_guest_to_be_up(
     let mut counter = 0;
     loop {
         tracing::info!("trying to poll guest {guest_name} to see if it is up ...");
-        let poll_res = SSHClient::run_guest_command(
-            common,
+
+        // this could succeed but the command fails with a non-zero exit code
+        let poll_res = libvirt::shell_command(
             command.clone(),
+            5000,
             machine_config,
-            false,
+            &format!("{}-{}", common.project_name, guest_name),
+            common,
+            logging_sender,
+            true,
         ).await;
+
         if counter > attempt_limit && poll_res.is_err() {
             // we waited 12 times with a wait, the command didnt work so this has failed
             bail!("could not connect to guest {}-{} to check if it is up, might not have booted successfully", &common.project_name, &machine_config.guest_type.name);

--- a/kvm-compose/kvm-compose/src/state/orchestration_tasks/guests.rs
+++ b/kvm-compose/kvm-compose/src/state/orchestration_tasks/guests.rs
@@ -409,8 +409,6 @@ impl OrchestrationGuestTask for ConfigLibvirtMachine {
                 if let Some(script) = setup_script {
                     tracing::info!("running setup script on guest {}", &machine_config.guest_type.name);
 
-                    // TODO - push file to guest using console mechanism
-
                     logging_sender.send(OrchestrationLogger::info("Waiting until guest is up before continuing".to_string())).await?;
                     wait_for_guest_to_be_up(&common, &machine_config, vec!["ls"], logging_sender).await?;
                     let local_script_path = parse_path_with_deployment_config(script, &common)?;
@@ -554,11 +552,67 @@ impl OrchestrationGuestTask for ConfigLibvirtMachine {
 
     async fn run_action(
         &self,
-        _common: OrchestrationCommon,
-        _machine_config: StateTestbedGuest,
-        _logging_sender: &Sender<OrchestrationLogger>,
+        common: OrchestrationCommon,
+        machine_config: StateTestbedGuest,
+        logging_sender: &Sender<OrchestrationLogger>,
     ) -> anyhow::Result<()> {
-        todo!()
+        let guest_name = format!("{}-{}", &common.project_name, &machine_config.guest_type.name);
+        match &self.libvirt_type {
+            LibvirtGuestOptions::CloudImage { run_script, .. } => {
+                // if the script exists, we will push the execution into the background
+                if let Some(script) = run_script {
+                    tracing::info!("running setup script on guest {}", &machine_config.guest_type.name);
+
+                    logging_sender.send(OrchestrationLogger::info("Waiting until guest is up before continuing".to_string())).await?;
+                    wait_for_guest_to_be_up(&common, &machine_config, vec!["ls"], logging_sender).await?;
+                    let local_script_path = parse_path_with_deployment_config(script, &common)?;
+
+                    logging_sender.send(OrchestrationLogger::info(format!("Pushing {local_script_path:?}"))).await?;
+                    libvirt::push(
+                        &ExecCmdFileTransfer {
+                            source_path: local_script_path.clone(),
+                            target_path: PathBuf::from("/opt"),
+                        },
+                        &machine_config,
+                        &guest_name,
+                        &common,
+                        logging_sender,
+                    ).await?;
+                    logging_sender.send(OrchestrationLogger::info(format!("Pushed {local_script_path:?}"))).await?;
+
+                    logging_sender.send(OrchestrationLogger::info("Executing run script".to_string())).await?;
+
+                    let script_file_name = {
+                        match local_script_path.file_name() {
+                            None => bail!("The script path given {local_script_path:?} is not a file, likely a directory."),
+                            Some(os_str) => {
+                                os_str.to_str().map(|s| s.to_string())
+                            }
+                        }
+                    };
+                    let script_file_name = script_file_name
+                        .context("Converting script name into a string")?;
+
+                    // run the setup script inthe background
+                    let (_, _) = libvirt::shell_command(
+                        // IMPORTANT - we run the script in the background, and also write a complete
+                        //  flag once it is done, which we will look for below to signal the command completed
+                        vec!["bash", format!("/opt/{script_file_name}").as_str(), "&"],
+                        5000,
+                        &machine_config,
+                        &guest_name,
+                        &common,
+                        logging_sender,
+                        true,
+                        true,
+                    ).await?;
+
+                }
+            }
+            LibvirtGuestOptions::ExistingDisk { .. } => {}
+            LibvirtGuestOptions::IsoGuest { .. } => {}
+        }
+        Ok(())
     }
 
     async fn destroy_action(

--- a/kvm-compose/kvm-compose/src/state/orchestration_tasks/guests.rs
+++ b/kvm-compose/kvm-compose/src/state/orchestration_tasks/guests.rs
@@ -478,7 +478,7 @@ impl OrchestrationGuestTask for ConfigLibvirtMachine {
                         &common,
                         logging_sender,
                         true,
-                        false,
+                        true,
                     ).await?;
 
                     // get the pid from the return text, should be the last string

--- a/kvm-compose/kvm-compose/src/state/orchestration_tasks/guests.rs
+++ b/kvm-compose/kvm-compose/src/state/orchestration_tasks/guests.rs
@@ -1626,6 +1626,7 @@ async fn wait_for_android_guest_to_be_up(
                 "while [[ -z $(getprop sys.boot_completed | tr -d '\r') ]]; do sleep 1; done;".to_string(),
             ],
             logging_sender,
+            true,
         ).await;
 
         if counter > attempt_limit && poll_res.is_err() {

--- a/kvm-compose/kvm-compose/src/state/orchestration_tasks/guests.rs
+++ b/kvm-compose/kvm-compose/src/state/orchestration_tasks/guests.rs
@@ -1620,7 +1620,11 @@ async fn wait_for_android_guest_to_be_up(
 
         let poll_res = exec::android::adb_command(
             &namespace,
-            &vec!["ls".to_string(), ".".to_string()],
+            &vec![
+                "wait-for-device".to_string(),
+                "shell".to_string(),
+                "while [[ -z $(getprop sys.boot_completed | tr -d '\r') ]]; do sleep 1; done;".to_string(),
+            ],
             logging_sender,
         ).await;
 

--- a/kvm-compose/kvm-compose/src/state/orchestration_tasks/mod.rs
+++ b/kvm-compose/kvm-compose/src/state/orchestration_tasks/mod.rs
@@ -179,6 +179,10 @@ impl OrchestrationTask for State {
             tracing::info!("Skipping guest setup scripts as guest have already been provisioned");
         }
 
+        // run scripts should always be run on the guest
+        tracing::info!("Stage: running any guest run scripts");
+        run_guest_run_scripts_stage(&self, sender).await?;
+
         Ok(())
     }
 

--- a/kvm-compose/kvm-compose/src/state/orchestration_tasks/mod.rs
+++ b/kvm-compose/kvm-compose/src/state/orchestration_tasks/mod.rs
@@ -12,10 +12,8 @@ use crate::components::helpers::xml::render_libvirt_network_xml;
 use crate::components::LogicalTestbed;
 use crate::get_project_folder_user_group;
 use crate::orchestration::*;
-use crate::orchestration::api::{OrchestrationInstruction, OrchestrationProtocol};
-use crate::orchestration::ssh::SSHClient;
+use crate::orchestration::api::{OrchestrationInstruction, OrchestrationLogger, OrchestrationProtocol};
 use crate::orchestration::websocket::{send_orchestration_instruction_over_channel};
-use crate::state::orchestration_tasks::guests::*;
 use crate::state::{State, StateTestbedGuestList};
 use crate::state::orchestration_tasks::stages::*;
 
@@ -61,211 +59,23 @@ pub async fn get_orchestration_common(
 /// in `State` rather than re-calculating `LogicalTestbed` then using that `State`.
 #[async_trait]
 impl OrchestrationTask for State {
-    async fn create_action(&self, common: &OrchestrationCommon) -> anyhow::Result<()> {
-        tracing::info!("running create action for testbed State");
-
-        check_if_testbed_hosts_up(&common).await?;
-
-        create_remote_project_folders(&common).await?;
-
-        // we separate creating the network into creating interfaces, then connecting them
-
-        // this will run either OVN or OVS implementation
-        self.network.create_action(common).await?;
-
-        // guest section, we collect futures and await them together here so that we can push images
-        // in parallel as it is an io blocking set of tasks
-
-        if !self.state_provisioning.guests_provisioned || common.force_provisioning {
-            tracing::info!("Stage: setting up any libvirt backing image guests");
-            // setup backing image guests
-            // setup clone backing images, the images are already made in artefact generation but if
-            // necessary, the next check deploys, runs shared setup and turns off ready to make clones
-            let mut backing_image_futures = Vec::new();
-
-            // check if we need to provision a temporary network for backing image guests that have
-            // a shared setup script
-            let net_provision = check_provision_temporary_network(&self.testbed_guests);
-            if net_provision {
-                tracing::info!("turning on temporary network for backing images with shared setup scripts");
-                turn_on_temporary_network(
-                    &common.project_name,
-                    &common.project_working_dir.to_str().context("getting project path")?.to_string(),
-                    common,
-                ).await?;
-            }
-
-            for (_guest_name, guest_data) in self.testbed_guests.0.iter() {
-                if guest_data.is_golden_image {
-                    match &guest_data.guest_type.guest_type {
-                        GuestType::Libvirt(libvirt) => {
-                            if guest_data.is_golden_image {
-                                backing_image_futures.push(
-                                    libvirt.setup_image_action(common.clone(), guest_data.clone())
-                                );
-                            }
-                        }
-                        GuestType::Docker(_) => unimplemented!(), // build from Dockerfile
-                        GuestType::Android(_) => unimplemented!(), // create AVD
-                    }
-                }
-            }
-            try_join_all(backing_image_futures).await?;
-            if net_provision {
-                tracing::info!("turning off temporary network for backing images with shared setup scripts");
-                turn_off_temporary_network(
-                    &common.project_name,
-                    &common.project_working_dir.to_str().context("getting project path")?.to_string()
-                ).await?;
-            }
-
-            tracing::info!("Stage: creating any libvirt clones of backing image guests");
-            // now backing images are created, we can loop again and create the linked clones
-            // setup linked clones
-            let mut clone_image_futures = Vec::new();
-            for (_guest_name, guest_data) in self.testbed_guests.0.iter() {
-                match &guest_data.guest_type.guest_type {
-                    GuestType::Libvirt(libvirt) => {
-                        if libvirt.is_clone_of.is_some() {
-                            clone_image_futures.push(
-                                libvirt.setup_image_action(common.clone(), guest_data.clone())
-                            );
-                        }
-                    }
-                    GuestType::Docker(_) => {} // not applicable
-                    GuestType::Android(_) => {} // not applicable
-                }
-            }
-            try_join_all(clone_image_futures).await?;
-        } else {
-            tracing::info!("skipping setting up backing image and creating clones as they have already been provisioned");
-        }
-
-        // if already been provisioned previously, this will only check if the images exist on the
-        // remote
-        tracing::info!("Stage: pushing guest images to remote testbed hosts");
-        // push normal and backing images to remote testbeds
-        let mut push_image_futures = Vec::new();
-        // push images for remote guests
-        for (_guest_name, guest_data) in self.testbed_guests.0.iter() {
-            match &guest_data.guest_type.guest_type {
-                GuestType::Libvirt(libvirt) => {
-                    push_image_futures.push(
-                        libvirt.push_image_action(common.clone(), guest_data.clone())
-                    );
-                }
-                GuestType::Docker(docker) => {
-                    push_image_futures.push(
-                        docker.push_image_action(common.clone(), guest_data.clone())
-                    );
-                }
-                GuestType::Android(_) => {} // Android guests currently only supported on main testbed host
-            }
-        }
-        // push backing images where necessary
-        let images_to_push = calculate_backing_images_to_push(&self, &common).await?;
-        for (backing_guest_name, target_testbed) in images_to_push.into_iter() {
-            // from the images_to_push set, work out the local path on main and the remote path
-            // on the target testbed host
-            let local_src = get_backing_image_local_path(
-                &self.testbed_guests,
-                &backing_guest_name)?;
-            let backing_image_remote_path = get_backing_image_remote_path(
-                &common,
-                &self.testbed_guests,
-                &backing_guest_name,
-                &target_testbed)?;
-            // remove the filename so we have just the parent folder
-            let remote_dst = PathBuf::from(backing_image_remote_path)
-                .parent().context("getting parent for backing image folder path")?
-                .to_str().context("converting parent folder to string")?
-                .to_string();
-
-            let target_testbed_host = target_testbed.clone();
-            push_image_futures.push(Box::pin(SSHClient::push_file_to_remote_testbed(&common, target_testbed_host, local_src, remote_dst, false)));
-        }
-        try_join_all(push_image_futures).await?;
-
-        // rebase clones on remote testbeds to point to the backing image we pushed
-        tracing::info!("Stage: rebasing clones on remote testbed hosts");
-        let mut rebase_futures = Vec::new();
-        for (_guest_name, guest_data) in self.testbed_guests.0.iter() {
-            // only rebase on remote testbeds
-            if !guest_data.testbed_host.as_ref().unwrap().eq(&get_main_testbed_name(&common)) {
-                match &guest_data.guest_type.guest_type {
-                    GuestType::Libvirt(libvirt) => {
-                        if libvirt.is_clone_of.is_some() {
-                            rebase_futures.push(libvirt.rebase_image_action(
-                                common.clone(),
-                                guest_data.clone(),
-                                self.testbed_guests.clone(),
-                            ));
-                        }
-                    }
-                    _ => {} // no rebasing for docker or android
-                }
-            }
-        }
-        try_join_all(rebase_futures).await?;
-
-        tracing::info!("Stage: deploying guests");
-        // deploy guests
-        let mut guest_deploy_futures = Vec::new();
-        for (_guest_name, guest_data) in self.testbed_guests.0.iter() {
-            match &guest_data.guest_type.guest_type {
-                GuestType::Libvirt(libvirt) => {
-                    // only deploy non backing images
-                    if !guest_data.is_golden_image {
-                        guest_deploy_futures.push(
-                            libvirt.create_action(common.clone(), guest_data.clone())
-                        );
-                    }
-                }
-                GuestType::Docker(docker) => {
-                    // only deploy definitions for scaled or normal definitions
-                    if docker.scaling.is_none() {
-                        guest_deploy_futures.push(
-                            docker.create_action(common.clone(), guest_data.clone())
-                        );
-                    }
-                }
-                GuestType::Android(android) => {
-                    if android.scaling.is_none() {
-                        guest_deploy_futures.push(
-                            android.create_action(common.clone(), guest_data.clone())
-                        );
-                    }
-                }
-            }
-        }
-        try_join_all(guest_deploy_futures).await?;
-
-        // if the guest has a setup script, execute it
-        if !self.state_provisioning.guests_provisioned || common.force_rerun_scripts {
-            // only run setup scripts if either forcing provisioning or state never been provisioned
-            tracing::info!("Stage: running any guest setup scripts");
-            let mut guest_setup_futures = Vec::new();
-            for (_guest_name, guest_data) in self.testbed_guests.0.iter() {
-                match &guest_data.guest_type.guest_type {
-                    GuestType::Libvirt(libvirt) => {
-                        guest_setup_futures.push(
-                            libvirt.setup_action(common.clone(), guest_data.clone())
-                        );
-                    }
-                    GuestType::Docker(_) => {} // not applicable at this time
-                    GuestType::Android(_) => {} // not applicable at this time
-                }
-            }
-            try_join_all(guest_setup_futures).await?;
-        } else {
-            tracing::info!("Skipping guest setup scripts as guest have already been provisioned");
-        }
-
-
-        Ok(())
+    async fn create_action(&self, _common: &OrchestrationCommon) -> anyhow::Result<()> {
+        // This create action function is not used for state anymore due to changes in the way
+        // the testbed deploys, now using the request_create_action which allows for the communication
+        // of logging back to the caller client.
+        // Realistically, this OrchestrationTask trait abstraction has not been totally used, it has
+        // only also been implemented for StateNetwork, so we should re-evaluate if we still need
+        // it or at least in this form i.e. with the redundant functions - this is due to changes
+        // in the testbed architecture moving to this client server model with bi-directional
+        // communication. We may need this trait for future implementations i.e. provisioning
+        // network interfaces on the host etc.
+        unimplemented!();
     }
 
-    async fn destroy_action(&self, common: &OrchestrationCommon) -> anyhow::Result<()> {
+    async fn destroy_action(&self, common: &OrchestrationCommon, logging_send: &Sender<OrchestrationLogger>) -> anyhow::Result<()> {
+        // TODO this is only used in the clear artefacts function, which could be changed to use
+        //  request_destroy_action - needs testing, as this also sends data back to client ..
+        //  see above create_action for more details
         tracing::info!("running destroy action for testbed State");
 
         check_if_testbed_hosts_up(&common).await?;
@@ -275,13 +85,13 @@ impl OrchestrationTask for State {
         for (_guest_name, guest_data) in self.testbed_guests.0.iter() {
             match &guest_data.guest_type.guest_type {
                 GuestType::Libvirt(libvirt) => {
-                    guest_destroy_futures.push(libvirt.destroy_action(common.clone(), guest_data.clone()));
+                    guest_destroy_futures.push(libvirt.destroy_action(common.clone(), guest_data.clone(), logging_send));
                 }
                 GuestType::Docker(docker) => {
-                    guest_destroy_futures.push(docker.destroy_action(common.clone(), guest_data.clone()));
+                    guest_destroy_futures.push(docker.destroy_action(common.clone(), guest_data.clone(), logging_send));
                 }
                 GuestType::Android(android) => {
-                    guest_destroy_futures.push(android.destroy_action(common.clone(), guest_data.clone()));
+                    guest_destroy_futures.push(android.destroy_action(common.clone(), guest_data.clone(), logging_send));
                 }
             }
         }
@@ -295,7 +105,7 @@ impl OrchestrationTask for State {
             &common.project_working_dir.to_str().context("getting project path")?.to_string()
         ).await?;
 
-        self.network.destroy_action(common).await?;
+        self.network.destroy_action(common, logging_send).await?;
 
         Ok(())
     }
@@ -405,10 +215,11 @@ impl OrchestrationTask for State {
 pub async fn clear_artefacts(
     state: &State,
     common: &OrchestrationCommon,
+    logging_send: &Sender<OrchestrationLogger>,
 ) -> anyhow::Result<()> {
     let project_name = &common.project_name;
     // make sure testbed is down
-    state.destroy_action(&common).await?;
+    state.destroy_action(&common, logging_send).await?;
     // special case for android
     for (guest_name, guest_data) in state.testbed_guests.0.iter() {
         match &guest_data.guest_type.guest_type {
@@ -636,3 +447,22 @@ pub async fn turn_off_temporary_network(
 //
 //     Ok(())
 // }
+
+/// Take in a path, if the path is an absolute path, then return as is, otherwise append the project
+/// directory as we will assume the path of the file specified in the yaml is relative to the
+/// project root.
+pub fn parse_path_with_deployment_config(
+    path: &PathBuf,
+    common: &OrchestrationCommon,
+) -> anyhow::Result<PathBuf> {
+
+    let path: &Path = &path;
+
+    let absolute_path = if path.is_absolute() {
+        path.canonicalize()?
+    } else {
+        common.project_working_dir.join(path).canonicalize()?
+    };
+
+    Ok(absolute_path)
+}

--- a/kvm-compose/kvm-compose/src/state/orchestration_tasks/ovn_network.rs
+++ b/kvm-compose/kvm-compose/src/state/orchestration_tasks/ovn_network.rs
@@ -137,7 +137,7 @@ impl OrchestrationTask for StateNetwork {
         Ok(())
     }
 
-    async fn destroy_action(&self, common: &OrchestrationCommon) -> anyhow::Result<()> {
+    async fn destroy_action(&self, common: &OrchestrationCommon, _logging_send: &Sender<OrchestrationLogger>) -> anyhow::Result<()> {
         tracing::info!("destroying OVN components");
 
         // destroy all OVN resources

--- a/kvm-compose/kvm-compose/src/state/orchestration_tasks/stages.rs
+++ b/kvm-compose/kvm-compose/src/state/orchestration_tasks/stages.rs
@@ -291,7 +291,11 @@ pub async fn run_guest_setup_scripts_stage(
                 );
             }
             GuestType::Docker(_) => {} // not applicable at this time
-            GuestType::Android(_) => {} // not applicable at this time
+            GuestType::Android(_) => {
+                orchestration_resources.push(
+                    OrchestrationResource::Guest(guest_data.clone())
+                );
+            }
         }
     }
     if orchestration_resources.is_empty() {
@@ -321,7 +325,11 @@ pub async fn run_guest_run_scripts_stage(
                 );
             }
             GuestType::Docker(_) => {} // not applicable at this time
-            GuestType::Android(_) => {} // not applicable at this time
+            GuestType::Android(_) => {
+                orchestration_resources.push(
+                    OrchestrationResource::Guest(guest_data.clone())
+                );
+            }
         }
     }
     if orchestration_resources.is_empty() {

--- a/kvm-compose/kvm-compose/src/state/orchestration_tasks/stages.rs
+++ b/kvm-compose/kvm-compose/src/state/orchestration_tasks/stages.rs
@@ -305,3 +305,33 @@ pub async fn run_guest_setup_scripts_stage(
 
     Ok(())
 }
+
+pub async fn run_guest_run_scripts_stage(
+    state: &State,
+    sender: &mut Sender<OrchestrationProtocol>,
+    // receiver: &mut Receiver<OrchestrationProtocol>,
+) -> anyhow::Result<()> {
+    let mut orchestration_resources = Vec::new();
+
+    for (_guest_name, guest_data) in state.testbed_guests.0.iter() {
+        match &guest_data.guest_type.guest_type {
+            GuestType::Libvirt(_) => {
+                orchestration_resources.push(
+                    OrchestrationResource::Guest(guest_data.clone())
+                );
+            }
+            GuestType::Docker(_) => {} // not applicable at this time
+            GuestType::Android(_) => {} // not applicable at this time
+        }
+    }
+    if orchestration_resources.is_empty() {
+        return Ok(());
+    }
+    send_orchestration_instruction_over_channel(
+        sender,
+        // receiver,
+        OrchestrationInstruction::ExecuteRunScript(orchestration_resources),
+    ).await.context("requesting the execution of guest run scripts")?;
+
+    Ok(())
+}

--- a/test-harness/py_harness/test_cases/mount.py
+++ b/test-harness/py_harness/test_cases/mount.py
@@ -35,13 +35,13 @@ class MountTestCase(TestCase):
             self.linked_clone_hosts,
             "_check_setup_script_artefact_exists",
         )
-        # context_artefact = run_command(
-        #     "client1",
-        #     "ls context/",
-        #     self.test_case_name,
-        #     self.linked_clone_hosts,
-        #     "_check_context_artefact_exists",
-        # )
+        context_artefact = run_command(
+            "client1",
+            "ls /etc/nocloud/context/",
+            self.test_case_name,
+            self.linked_clone_hosts,
+            "_check_context_artefact_exists",
+        )
         # env_var = run_command(
         #     "client1",
         #     """[ -n "${MOUNT_ENV_TEST}" ] && exit 0 || exit 1""",
@@ -77,7 +77,7 @@ class MountTestCase(TestCase):
             up_result_report,
             run_script_artefact,
             setup_script_artefact,
-            # context_artefact,
+            context_artefact,
             # env_var,
             # env_file_var_docker,
             # env_var_docker,

--- a/test-harness/py_harness/test_cases/mount.py
+++ b/test-harness/py_harness/test_cases/mount.py
@@ -84,4 +84,4 @@ class MountTestCase(TestCase):
             mount_docker,
         ]
 
-# registered_test_cases.append(MountTestCase)
+registered_test_cases.append(MountTestCase)

--- a/test-harness/py_harness/test_cases/mount.py
+++ b/test-harness/py_harness/test_cases/mount.py
@@ -35,13 +35,13 @@ class MountTestCase(TestCase):
             self.linked_clone_hosts,
             "_check_setup_script_artefact_exists",
         )
-        # context_artefact = run_command(
-        #     "client1",
-        #     "ls /etc/nocloud/context/",
-        #     self.test_case_name,
-        #     self.linked_clone_hosts,
-        #     "_check_context_artefact_exists",
-        # )
+        context_artefact = run_command(
+            "client1",
+            "ls /etc/nocloud/context/",
+            self.test_case_name,
+            self.linked_clone_hosts,
+            "_check_context_artefact_exists",
+        )
         # env_var = run_command(
         #     "client1",
         #     """[ -n "${MOUNT_ENV_TEST}" ] && exit 0 || exit 1""",
@@ -84,4 +84,4 @@ class MountTestCase(TestCase):
             mount_docker,
         ]
 
-registered_test_cases.append(MountTestCase)
+# registered_test_cases.append(MountTestCase)

--- a/test-harness/py_harness/test_cases/mount.py
+++ b/test-harness/py_harness/test_cases/mount.py
@@ -35,36 +35,36 @@ class MountTestCase(TestCase):
             self.linked_clone_hosts,
             "_check_setup_script_artefact_exists",
         )
-        context_artefact = run_command(
-            "client1",
-            "ls context/",
-            self.test_case_name,
-            self.linked_clone_hosts,
-            "_check_context_artefact_exists",
-        )
-        env_var = run_command(
-            "client1",
-            """[ -n "${MOUNT_ENV_TEST}" ] && exit 0 || exit 1""",
-            self.test_case_name,
-            self.linked_clone_hosts,
-            "_check_env_var_exists",
-        )
+        # context_artefact = run_command(
+        #     "client1",
+        #     "ls context/",
+        #     self.test_case_name,
+        #     self.linked_clone_hosts,
+        #     "_check_context_artefact_exists",
+        # )
+        # env_var = run_command(
+        #     "client1",
+        #     """[ -n "${MOUNT_ENV_TEST}" ] && exit 0 || exit 1""",
+        #     self.test_case_name,
+        #     self.linked_clone_hosts,
+        #     "_check_env_var_exists",
+        # )
 
         ### docker
-        env_file_var_docker = run_command(
-            "client2",
-            """[ -n "${DOCKER_ENV}" ] && exit 0 || exit 1""",
-            self.test_case_name,
-            self.linked_clone_hosts,
-            "_check_env_file_var_exists_docker",
-        )
-        env_var_docker = run_command(
-            "client2",
-            """[ -n "${TWO}" ] && exit 0 || exit 1""",
-            self.test_case_name,
-            self.linked_clone_hosts,
-            "_check_env_var_exists_docker",
-        )
+        # env_file_var_docker = run_command(
+        #     "client2",
+        #     """[ -n "${DOCKER_ENV}" ] && exit 0 || exit 1""",
+        #     self.test_case_name,
+        #     self.linked_clone_hosts,
+        #     "_check_env_file_var_exists_docker",
+        # )
+        # env_var_docker = run_command(
+        #     "client2",
+        #     """[ -n "${TWO}" ] && exit 0 || exit 1""",
+        #     self.test_case_name,
+        #     self.linked_clone_hosts,
+        #     "_check_env_var_exists_docker",
+        # )
         mount_docker = run_command(
             "client2",
             "ls /opt/context",
@@ -77,12 +77,11 @@ class MountTestCase(TestCase):
             up_result_report,
             run_script_artefact,
             setup_script_artefact,
-            context_artefact,
-            env_var,
-            env_file_var_docker,
-            env_var_docker,
+            # context_artefact,
+            # env_var,
+            # env_file_var_docker,
+            # env_var_docker,
             mount_docker,
         ]
 
-# TODO - commenting out this test case for now as the bugs are failing the test - to be fixed in 288
-# registered_test_cases.append(MountTestCase)
+registered_test_cases.append(MountTestCase)

--- a/test-harness/py_harness/test_cases/mount.py
+++ b/test-harness/py_harness/test_cases/mount.py
@@ -35,13 +35,13 @@ class MountTestCase(TestCase):
             self.linked_clone_hosts,
             "_check_setup_script_artefact_exists",
         )
-        context_artefact = run_command(
-            "client1",
-            "ls /etc/nocloud/context/",
-            self.test_case_name,
-            self.linked_clone_hosts,
-            "_check_context_artefact_exists",
-        )
+        # context_artefact = run_command(
+        #     "client1",
+        #     "ls /etc/nocloud/context/",
+        #     self.test_case_name,
+        #     self.linked_clone_hosts,
+        #     "_check_context_artefact_exists",
+        # )
         # env_var = run_command(
         #     "client1",
         #     """[ -n "${MOUNT_ENV_TEST}" ] && exit 0 || exit 1""",

--- a/test-harness/py_harness/test_cases/mount/kvm-compose.yaml
+++ b/test-harness/py_harness/test_cases/mount/kvm-compose.yaml
@@ -15,7 +15,7 @@ machines:
           expand_gigabytes: 2
           run_script: ./run.sh
           setup_script: ./setup.sh
-          context: ./context/
+#          context: ./context/
           environment:
             MOUNT_ENV_TEST: "123"
 

--- a/test-harness/py_harness/test_cases/mount/kvm-compose.yaml
+++ b/test-harness/py_harness/test_cases/mount/kvm-compose.yaml
@@ -15,7 +15,7 @@ machines:
           expand_gigabytes: 2
           run_script: ./run.sh
           setup_script: ./setup.sh
-#          context: ./context/
+          context: ./context/
           environment:
             MOUNT_ENV_TEST: "123"
 

--- a/test-harness/py_harness/test_cases/mount/kvm-compose.yaml
+++ b/test-harness/py_harness/test_cases/mount/kvm-compose.yaml
@@ -27,7 +27,7 @@ machines:
         ip: "10.0.0.12"
     docker:
       image: nginx:stable
-      env_file: docker.env
+#      env_file: docker.env
       environment:
         TWO: "2"
       volumes:


### PR DESCRIPTION
This PR enables the usage of setup and run scripts for libvirt guests. This means you can run some script on boot that will install dependencies (setup script) and then another script that will be run when the guest starts (run script). These scripts are mounted into the guest via CDROM, before being executed inside the guest.

The same has been added for android guests, but this is mostly just a convenience of running arbitrary scripts when the emulator is ready. So for the setup script you can run a `wget` to download an `.apk` file, then use `kvm-compose exec <guestname> tool adb install <apk location>` inside the script to pre-prepare the emulator. The script will be executed from the project root (next to the kvm-compose.yaml) so the `kvm-compose` cli will be able to see the `state.json` to know the emulator details to connect.

In this PR a fix for the android emulator create command has been added, as part of the work that needed this PR also needed this tiny update. The fix is just for any api version of android later than 31, we need to change the architecture to `x86_64` as it seems the do not provide just `x86` anymore. We should probably just use `x86_64` anyway for the older ones, but keeping it like this for backwards compatibility just in case. 