### PR TITLE
Android tooling upgrades

### DIFF
--- a/kvm-compose/Cargo.lock
+++ b/kvm-compose/Cargo.lock
@@ -398,6 +398,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55b672471b4e9f9e95499ea597ff64941a309b2cdbffcc46f2cc5e2d971fd335"
 
 [[package]]
+name = "command-group"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a68fa787550392a9d58f44c21a3022cfb3ea3e2458b7f85d3b399d0ceeccf409"
+dependencies = [
+ "async-trait",
+ "nix 0.27.1",
+ "tokio",
+ "winapi",
+]
+
+[[package]]
 name = "compact_str"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1325,12 +1337,13 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
+ "command-group",
  "console",
  "futures-util",
  "glob",
  "kvm-compose-schemas",
  "lazy_static",
- "nix",
+ "nix 0.30.1",
  "rand 0.9.1",
  "reqwest",
  "rexpect",
@@ -1355,7 +1368,7 @@ dependencies = [
  "crossterm 0.29.0",
  "kvm-compose",
  "kvm-compose-schemas",
- "nix",
+ "nix 0.30.1",
  "ratatui",
  "reqwest",
  "tokio",
@@ -1371,7 +1384,7 @@ dependencies = [
  "chrono",
  "clap",
  "futures",
- "nix",
+ "nix 0.30.1",
  "reqwest",
  "serde",
  "serde_json",
@@ -1530,6 +1543,17 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -2073,7 +2097,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c1bcd4ac488e9d2d726d147031cceff5cff6425011ff1914049739770fa4726"
 dependencies = [
  "comma",
- "nix",
+ "nix 0.30.1",
  "regex",
  "tempfile",
  "thiserror 2.0.12",
@@ -2556,7 +2580,7 @@ dependencies = [
  "glob",
  "kvm-compose",
  "kvm-compose-schemas",
- "nix",
+ "nix 0.30.1",
  "regex",
  "reqwest",
  "serde",

--- a/kvm-compose/kvm-compose-cli/src/main.rs
+++ b/kvm-compose/kvm-compose-cli/src/main.rs
@@ -102,7 +102,7 @@ pub async fn parse_command(opts: Opts) -> anyhow::Result<()> {
     // we will capture a ctrl+c here in case the command gets stuck, as there is a possibility that
     // we could get stuck after the command is run (where we also have another ctrl+c listener)
     // ... when this exits, this will close the websocket connection so the server should tear down
-    // the running command 
+    // the running command
 
     let command_block = tokio::spawn(async move {
         let sub_command = match &opts.sub_command {
@@ -127,8 +127,13 @@ pub async fn parse_command(opts: Opts) -> anyhow::Result<()> {
     });
 
     tokio::select! {
-        _ = command_block => {}
-        _ = interrupt_block => {}
+        result = command_block => {
+            // propagate if there was a failure in the command executed
+            result??;
+        }
+        _ = interrupt_block => {
+            bail!("exiting interrupted kvm-compose");
+        }
     }
 
     Ok(())

--- a/kvm-compose/kvm-compose-cli/src/main.rs
+++ b/kvm-compose/kvm-compose-cli/src/main.rs
@@ -99,19 +99,37 @@ pub async fn parse_command(opts: Opts) -> anyhow::Result<()> {
         bail!("could not connect to testbed server at {}, is it running?", opts.server_connection);
     }
 
-    let sub_command = match &opts.sub_command {
-        SubCommand::GenerateArtefacts => client::orchestration_action(&client, opts).await,
-        SubCommand::ClearArtefacts => client::orchestration_action(&client, opts).await,
-        SubCommand::Deployment(dep_cmd) => client::deployment_action(&client, &opts, dep_cmd).await,
-        SubCommand::Up(_) => client::orchestration_action(&client, opts).await,
-        SubCommand::Down => client::orchestration_action(&client, opts).await,
-        SubCommand::Snapshot(_) => client::orchestration_action(&client, opts).await,
-        SubCommand::AnalysisTools(_) => unimplemented!(), // unimplemented while we are reworking tcpdump
-        SubCommand::TestbedSnapshot(_) => client::orchestration_action(&client, opts).await,
-        SubCommand::Exec(_) => client::orchestration_action(&client, opts).await,
-        _ => bail!("command not matched, please raise an issue"),
-    };
-    sub_command
-        .context("running CLI command")?;
+    // we will capture a ctrl+c here in case the command gets stuck, as there is a possibility that
+    // we could get stuck after the command is run (where we also have another ctrl+c listener)
+    // ... when this exits, this will close the websocket connection so the server should tear down
+    // the running command 
+
+    let command_block = tokio::spawn(async move {
+        let sub_command = match &opts.sub_command {
+            SubCommand::GenerateArtefacts => client::orchestration_action(&client, opts).await,
+            SubCommand::ClearArtefacts => client::orchestration_action(&client, opts).await,
+            SubCommand::Deployment(dep_cmd) => client::deployment_action(&client, &opts, dep_cmd).await,
+            SubCommand::Up(_) => client::orchestration_action(&client, opts).await,
+            SubCommand::Down => client::orchestration_action(&client, opts).await,
+            SubCommand::Snapshot(_) => client::orchestration_action(&client, opts).await,
+            SubCommand::AnalysisTools(_) => unimplemented!(), // unimplemented while we are reworking tcpdump
+            SubCommand::TestbedSnapshot(_) => client::orchestration_action(&client, opts).await,
+            SubCommand::Exec(_) => client::orchestration_action(&client, opts).await,
+            _ => bail!("command not matched, please raise an issue"),
+        };
+        sub_command
+            .context("running CLI command")?;
+        Ok(())
+    });
+    let interrupt_block = tokio::spawn(async move {
+        let _ = tokio::signal::ctrl_c().await;
+        tracing::info!("captured ctrl + C, gracefully stopping command");
+    });
+
+    tokio::select! {
+        _ = command_block => {}
+        _ = interrupt_block => {}
+    }
+
     Ok(())
 }

--- a/kvm-compose/kvm-compose-schemas/src/exec.rs
+++ b/kvm-compose/kvm-compose-schemas/src/exec.rs
@@ -86,6 +86,9 @@ pub enum TestbedTools {
     FridaSetup,
     TestPermissions(Command),
     TestPrivacy(Command),
+    /// TLS Intercept, you must pass two arguments as <packagename> <outdir> where package name is
+    /// the name of the app if it is running, or the full name of the app including the organisation
+    /// i.e. org.testbed.application
     TLSIntercept(Command),
 }
 

--- a/kvm-compose/kvm-compose/Cargo.toml
+++ b/kvm-compose/kvm-compose/Cargo.toml
@@ -34,3 +34,4 @@ rexpect = "0.6.2"
 virt = { workspace = true }
 tempfile = "3.17.1"
 console = "0.16.0"
+command-group = { version = "5.0.1", features = ["with-tokio"] }

--- a/kvm-compose/kvm-compose/src/analysis_tools/packet_capture.rs
+++ b/kvm-compose/kvm-compose/src/analysis_tools/packet_capture.rs
@@ -1,10 +1,14 @@
+use std::sync::Arc;
 use std::time::Duration;
+use tokio::sync::mpsc::{Receiver};
+use tokio::sync::Mutex;
 use kvm_compose_schemas::cli_models::AnalysisToolsCmd;
 
 /// Run the packet capture. This function needs to work out which testbed host this capture needs to
 /// run on. This function also needs to work out if the
 pub async fn packet_capture(
-    at: &AnalysisToolsCmd
+    at: &AnalysisToolsCmd,
+    _cancel_token_recv: Arc<Mutex<Receiver<()>>>
 ) -> anyhow::Result<()> {
     //
     tracing::info!("tcpdump args: {at:?}");

--- a/kvm-compose/kvm-compose/src/exec/android.rs
+++ b/kvm-compose/kvm-compose/src/exec/android.rs
@@ -1,9 +1,12 @@
 use tokio::time::Duration;
 use tokio::process::{Command};
-use std::process::Output;
 use anyhow::{bail, Context};
 use std::path::Path;
-use tokio::sync::mpsc::Sender;
+use std::process::Stdio;
+use std::sync::Arc;
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::sync::mpsc::{Receiver, Sender};
+use tokio::sync::Mutex;
 use crate::orchestration::api::{OrchestrationLogger};
 use crate::orchestration::OrchestrationCommon;
 use crate::state::StateTestbedGuest;
@@ -149,13 +152,7 @@ pub async fn test_permissions(
     logging_send: &Sender<OrchestrationLogger>,
 ) -> anyhow::Result<()> {
 
-    // Get path of poetry venv
-    let output = get_frida_tools_env().await?;
-
-    let venv = String::from_utf8_lossy(&output.stdout);
-    let venv_path = format!("{}/bin/python", venv.trim_end());
-
-    tracing::info!("Poetry env is {}", venv_path);
+    let venv_path = format!("/var/lib/testbedos/tools/frida_tools_venv/bin/python");
 
     let mut args = vec![
         "ip".to_string(),
@@ -192,15 +189,10 @@ pub async fn tls_intercept(
     namespace: &str,
     command: &Vec<String>,
     logging_send: &Sender<OrchestrationLogger>,
+    cancel_token_recv: Arc<Mutex<Receiver<()>>>,
 ) -> anyhow::Result<()> {
 
-    // Get path of poetry venv
-    let output = get_frida_tools_env().await?;
-
-    let venv = String::from_utf8_lossy(&output.stdout);
-    let venv_path = format!("{}/bin/python", venv.trim_end());
-
-    tracing::info!("Poetry env is {}", venv_path);
+    let venv_path = format!("/var/lib/testbedos/tools/frida_tools_venv/bin/python");
 
     let mut args = vec![
         "ip".to_string(),
@@ -216,19 +208,79 @@ pub async fn tls_intercept(
 
     tracing::info!("Running command: sudo {}", args.join(" "));
 
-    let output = Command::new("sudo")
-        .args(&args)
-        .output()
-        .await
-        .context("Failed to execute intercept command")?;
+    // TODO - how to fix relative paths given to the CLI/GUI and then what the script sees, so
+    //  currently a relative path will try to put the output in the Frida-Tools folder
 
-    if output.status.success() {
-        let log = String::from_utf8_lossy(&output.stdout);
-        tracing::info!("output: {:?}", log);
-        logging_send.send(OrchestrationLogger::info(log.to_string())).await?;
-    } else {
-        bail!("error: {:?}", String::from_utf8_lossy(&output.stderr));
+    let mut child = Command::new("sudo")
+        .args(&args)
+        .current_dir("/var/lib/testbedos/tools/Frida-Tools")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .context("Spawning tls intercept command")?;
+
+    let stdout = child.stdout.take().context("Child did not have stdout")?;
+    let stderr = child.stderr.take().context("Child did not have stderr")?;
+    let mut stdout_reader = BufReader::new(stdout).lines();
+    let mut stderr_reader = BufReader::new(stderr).lines();
+
+    let pid = child.id().context("getting tls intercept pid")?;
+    tracing::info!("Got tls intercept pid {}", pid);
+
+    let mut recv_lock = cancel_token_recv.lock().await;
+
+    logging_send.send(OrchestrationLogger::info("The following is tls-interceptor logs ========".to_string())).await?;
+
+    // loop here on the tokio select! as we will be sending back to the client the logging from
+    loop {
+        tokio::select! {
+            output = child.wait() => {
+                // this will run if the command exits by itself
+                let status = output?;
+                if status.success() {
+                    logging_send.send(OrchestrationLogger::info("tls-interceptor exited successfully".to_string())).await?;
+                    break;
+                } else {
+                    bail!("tls-interceptor did not exit successfully");
+                }
+            }
+            cancel = recv_lock.recv() => {
+                // this will run if a cancel token is received
+                tracing::info!("received cancel token in tls intercept");
+                if let Some(token) = cancel {
+                    // kill the process
+                    // let result = nix::sys::signal::kill(
+                    //     nix::unistd::Pid::from_raw(pid as i32),
+                    //     nix::sys::signal::Signal::SIGKILL,
+                    // );
+
+                    // TODO why is the pid always 2 below the actual pid - this isn't killing the tls-intercept
+                    //  maybe run it as a shell?
+
+                    let _ = child.kill().await?;
+
+                    break;
+                }
+            }
+            // the following two branches are for the live logging from the command
+            stdout_line = stdout_reader.next_line() => {
+                match stdout_line {
+                    Ok(Some(line)) => logging_send.send(OrchestrationLogger::info(line)).await?,
+                    Ok(None) => {},
+                    Err(err) => logging_send.send(OrchestrationLogger::error(err.to_string())).await?,
+                }
+            }
+            stderr_line = stderr_reader.next_line() => {
+                match stderr_line {
+                    Ok(Some(line)) => logging_send.send(OrchestrationLogger::error(line)).await?,
+                    Ok(None) => {},
+                    Err(err) => logging_send.send(OrchestrationLogger::error(err.to_string())).await?,
+                }
+            }
+        }
     }
+
+    logging_send.send(OrchestrationLogger::info("End of tls-interceptor logging ========".to_string())).await?;
 
     Ok(())
 }
@@ -267,16 +319,4 @@ pub async fn test_privacy(
     }
 
     Ok(())
-}
-
-async fn get_frida_tools_env() -> anyhow::Result<Output> {
-    Command::new("sudo")
-        .arg("/var/lib/testbedos/tools/frida_tools_venv/bin/poetry")
-        .arg("env")
-        .arg("info")
-        .arg("-p")
-        .current_dir("/var/lib/testbedos/tools/Frida-Tools")
-        .output()
-        .await
-        .context("Failed to get python environment for frida tools, is it installed at '/var/lib/testbedos/tools/Frida-Tools'?")
 }

--- a/kvm-compose/kvm-compose/src/exec/android.rs
+++ b/kvm-compose/kvm-compose/src/exec/android.rs
@@ -67,6 +67,10 @@ pub async fn frida_setup(
     logging_send: &Sender<OrchestrationLogger>,
 ) -> anyhow::Result<()> {
 
+    adb_command(namespace, &vec!["start-server".to_string()], &logging_send, false)
+        .await
+        .context("making sure adb server is running on device")?;
+
     // we need to know if the emulator is x86 or x86_64, we can use an adb command to do this
     let res = adb_command(
         namespace,
@@ -192,6 +196,10 @@ pub async fn tls_intercept(
     logging_send: &Sender<OrchestrationLogger>,
     cancel_token_recv: Arc<Mutex<Receiver<()>>>,
 ) -> anyhow::Result<()> {
+
+    adb_command(namespace, &vec!["start-server".to_string()], &logging_send, false)
+        .await
+        .context("making sure adb server is running on device")?;
 
     let venv_path = format!("/var/lib/testbedos/tools/frida_tools_venv/bin/python");
 

--- a/kvm-compose/kvm-compose/src/exec/android.rs
+++ b/kvm-compose/kvm-compose/src/exec/android.rs
@@ -25,7 +25,7 @@ pub async fn adb_command(
     command: &Vec<String>,
     logging_send: &Sender<OrchestrationLogger>,
     suppress_output: bool,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<String> {
 
     let mut args = vec![
         "ip".to_string(),
@@ -47,16 +47,15 @@ pub async fn adb_command(
 
     if output.status.success() {
         let log = String::from_utf8_lossy(&output.stdout);
-        tracing::info!("ADB output: {:?}", String::from_utf8_lossy(&output.stdout));
+        tracing::info!("ADB output: {:?}", log);
         if !suppress_output {
             logging_send.send(OrchestrationLogger::info(log.to_string())).await?;
         }
+        Ok(log.to_string())
     } else {
         bail!("ADB error: {:?}", String::from_utf8_lossy(&output.stderr));
     }
 
-
-    Ok(())
 }
 
 pub async fn frida_setup(
@@ -64,12 +63,27 @@ pub async fn frida_setup(
     logging_send: &Sender<OrchestrationLogger>,
 ) -> anyhow::Result<()> {
 
+    // we need to know if the emulator is x86 or x86_64, we can use an adb command to do this
+    let res = adb_command(
+        namespace,
+        &vec!["shell".to_string(), "getprop".to_string(), "ro.product.cpu.abi".to_string()],
+        &logging_send,
+        true,
+    ).await;
+    let abi = match res {
+        Ok(ok) => ok,
+        Err(e) => bail!("could not determine the abi version for the emulator: {e:#}"),
+    };
+
+    // remove whitespaces and newlines
+    let abi = abi.trim().to_string();
+
     // Install frida server if it doesn't exist
-    if !Path::new("/var/lib/testbedos/tools/frida-server-16.1.4-android-x86").exists() {
+    if !Path::new(&format!("/var/lib/testbedos/tools/frida-server-16.1.4-android-{abi}")).exists() {
         tracing::info!("Installing frida server");
         let output = Command::new("sudo")
             .arg("wget")
-            .arg("https://github.com/frida/frida/releases/download/16.1.4/frida-server-16.1.4-android-x86.xz")
+            .arg(format!("https://github.com/frida/frida/releases/download/16.1.4/frida-server-16.1.4-android-{abi}.xz"))
             .arg("-P")
             .arg("/var/lib/testbedos/tools/")
             .output()
@@ -82,7 +96,7 @@ pub async fn frida_setup(
 
         Command::new("sudo")
             .arg("unxz")
-            .arg("/var/lib/testbedos/tools/frida-server-16.1.4-android-x86.xz")
+            .arg(format!("/var/lib/testbedos/tools/frida-server-16.1.4-android-{abi}.xz"))
             .output()
             .await
             .context("Failed to extract server")?;
@@ -106,12 +120,12 @@ pub async fn frida_setup(
     tracing::info!("waiting to give a chance for rooting to complete before continuing ...");
     tokio::time::sleep(Duration::from_secs(2)).await;
 
-    adb_command(namespace, &vec!["push".to_string(), "/var/lib/testbedos/tools/frida-server-16.1.4-android-x86".to_string(), "/data/local/tmp".to_string()], &logging_send, false).await?;
-    adb_command(namespace, &vec!["shell".to_string(), "chmod".to_string(), "755".to_string(), "/data/local/tmp/frida-server-16.1.4-android-x86".to_string()], &logging_send, false).await?;
+    adb_command(namespace, &vec!["push".to_string(), format!("/var/lib/testbedos/tools/frida-server-16.1.4-android-{abi}"), "/data/local/tmp".to_string()], &logging_send, false).await?;
+    adb_command(namespace, &vec!["shell".to_string(), "chmod".to_string(), "755".to_string(), format!("/data/local/tmp/frida-server-16.1.4-android-{abi}")], &logging_send, false).await?;
 
     // Added -D to daemonize and -C to ignore crashes, which seems to prevent frida from holding
     // up the terminal so it exits - unclear if this is causing side effects yet
-    let res = adb_command(namespace, &vec!["shell".to_string(), "/data/local/tmp/frida-server-16.1.4-android-x86 -D -C".to_string()], &logging_send, false).await;
+    let res = adb_command(namespace, &vec!["shell".to_string(), format!("/data/local/tmp/frida-server-16.1.4-android-{abi} -D -C")], &logging_send, false).await;
     match res {
         Ok(_) => {}
         Err(e) => {

--- a/kvm-compose/kvm-compose/src/exec/android.rs
+++ b/kvm-compose/kvm-compose/src/exec/android.rs
@@ -79,11 +79,11 @@ pub async fn frida_setup(
     let abi = abi.trim().to_string();
 
     // Install frida server if it doesn't exist
-    if !Path::new(&format!("/var/lib/testbedos/tools/frida-server-16.1.4-android-{abi}")).exists() {
+    if !Path::new(&format!("/var/lib/testbedos/tools/frida-server-17.2.15-android-{abi}")).exists() {
         tracing::info!("Installing frida server");
         let output = Command::new("sudo")
             .arg("wget")
-            .arg(format!("https://github.com/frida/frida/releases/download/16.1.4/frida-server-16.1.4-android-{abi}.xz"))
+            .arg(format!("https://github.com/frida/frida/releases/download/17.2.15/frida-server-17.2.15-android-{abi}.xz"))
             .arg("-P")
             .arg("/var/lib/testbedos/tools/")
             .output()
@@ -96,7 +96,7 @@ pub async fn frida_setup(
 
         Command::new("sudo")
             .arg("unxz")
-            .arg(format!("/var/lib/testbedos/tools/frida-server-16.1.4-android-{abi}.xz"))
+            .arg(format!("/var/lib/testbedos/tools/frida-server-17.2.15-android-{abi}.xz"))
             .output()
             .await
             .context("Failed to extract server")?;
@@ -120,12 +120,12 @@ pub async fn frida_setup(
     tracing::info!("waiting to give a chance for rooting to complete before continuing ...");
     tokio::time::sleep(Duration::from_secs(2)).await;
 
-    adb_command(namespace, &vec!["push".to_string(), format!("/var/lib/testbedos/tools/frida-server-16.1.4-android-{abi}"), "/data/local/tmp".to_string()], &logging_send, false).await?;
-    adb_command(namespace, &vec!["shell".to_string(), "chmod".to_string(), "755".to_string(), format!("/data/local/tmp/frida-server-16.1.4-android-{abi}")], &logging_send, false).await?;
+    adb_command(namespace, &vec!["push".to_string(), format!("/var/lib/testbedos/tools/frida-server-17.2.15-android-{abi}"), "/data/local/tmp".to_string()], &logging_send, false).await?;
+    adb_command(namespace, &vec!["shell".to_string(), "chmod".to_string(), "755".to_string(), format!("/data/local/tmp/frida-server-17.2.15-android-{abi}")], &logging_send, false).await?;
 
     // Added -D to daemonize and -C to ignore crashes, which seems to prevent frida from holding
     // up the terminal so it exits - unclear if this is causing side effects yet
-    let res = adb_command(namespace, &vec!["shell".to_string(), format!("/data/local/tmp/frida-server-16.1.4-android-{abi} -D -C")], &logging_send, false).await;
+    let res = adb_command(namespace, &vec!["shell".to_string(), format!("/data/local/tmp/frida-server-17.2.15-android-{abi} -D -C")], &logging_send, false).await;
     match res {
         Ok(_) => {}
         Err(e) => {

--- a/kvm-compose/kvm-compose/src/exec/android.rs
+++ b/kvm-compose/kvm-compose/src/exec/android.rs
@@ -250,18 +250,8 @@ pub async fn tls_intercept(
             cancel = recv_lock.recv() => {
                 // this will run if a cancel token is received
                 tracing::info!("received cancel token in tls intercept");
-                if let Some(token) = cancel {
-                    // kill the process
-                    // let result = nix::sys::signal::kill(
-                    //     nix::unistd::Pid::from_raw(pid as i32),
-                    //     nix::sys::signal::Signal::SIGKILL,
-                    // );
-
-                    // TODO why is the pid always 2 below the actual pid - this isn't killing the tls-intercept
-                    //  maybe run it as a shell?
-
+                if let Some(_) = cancel {
                     let _ = child.kill().await?;
-
                     break;
                 }
             }

--- a/kvm-compose/kvm-compose/src/exec/android.rs
+++ b/kvm-compose/kvm-compose/src/exec/android.rs
@@ -4,6 +4,7 @@ use anyhow::{bail, Context};
 use std::path::Path;
 use std::process::Stdio;
 use std::sync::Arc;
+use command_group::AsyncCommandGroup;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::sync::mpsc::{Receiver, Sender};
 use tokio::sync::Mutex;
@@ -216,11 +217,13 @@ pub async fn tls_intercept(
         .current_dir("/var/lib/testbedos/tools/Frida-Tools")
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
-        .spawn()
+        .group_spawn()
         .context("Spawning tls intercept command")?;
 
-    let stdout = child.stdout.take().context("Child did not have stdout")?;
-    let stderr = child.stderr.take().context("Child did not have stderr")?;
+    let inner = child.inner();
+
+    let stdout = inner.stdout.take().context("Child did not have stdout")?;
+    let stderr = inner.stderr.take().context("Child did not have stderr")?;
     let mut stdout_reader = BufReader::new(stdout).lines();
     let mut stderr_reader = BufReader::new(stderr).lines();
 

--- a/kvm-compose/kvm-compose/src/exec/file_transfer.rs
+++ b/kvm-compose/kvm-compose/src/exec/file_transfer.rs
@@ -13,6 +13,7 @@ const CDROM_DEVICE_XML: &str = r#"
     <disk type='file' device='cdrom'>
         <driver name='qemu' type='raw'/>
         <target dev='sdc' bus='scsi'/>
+        <source file='VALID_ISO_PATH'/>
         <readonly/>
         <address type='drive' controller='0' bus='0' target='0' unit='2'/>
     </disk>
@@ -62,18 +63,17 @@ pub async fn attach_cdrom_to_guest(
         .context("connecting to libvirt to get attach CD ROM device")?;
     let domain = virt::domain::Domain::lookup_by_name(&conn, guest_name_with_project)
         .context("getting domain from libvirt connection")?;
-    // insert the scsi CD ROM device via an XML definition (will not persist between guest boots)
-    domain.attach_device(CDROM_DEVICE_XML)
-        .context("Attaching CD ROM device to guest")?;
 
-    // attach the media
+    // we need to create a temporary xml with the full path to the ISO file, we replace the
+    // existing template with the temp iso path
+    let mut temp_cdrom_xml = CDROM_DEVICE_XML.to_string();
     let temp_iso_str_path = temp_iso.path().to_string_lossy().into_owned();
-    run_subprocess_command(
-        "sudo",
-        vec!["virsh", "change-media", &guest_name_with_project, "sdc", &temp_iso_str_path],
-        false,
-        None,
-    ).await?;
+    temp_cdrom_xml = temp_cdrom_xml.replace("VALID_ISO_PATH", &temp_iso_str_path);
+
+    // TODO - if we are going to attach another, do we need to do any clearup of the previous cdrom?
+    // insert the scsi CD ROM device via an XML definition (will not persist between guest boots)
+    domain.attach_device(&temp_cdrom_xml)
+        .context("Attaching CD ROM device to guest")?;
 
     Ok(())
 }

--- a/kvm-compose/kvm-compose/src/exec/mod.rs
+++ b/kvm-compose/kvm-compose/src/exec/mod.rs
@@ -3,8 +3,10 @@ pub mod docker;
 pub mod libvirt;
 pub mod file_transfer;
 
+use std::sync::Arc;
 use anyhow::{bail, Context};
-use tokio::sync::mpsc::Sender;
+use tokio::sync::mpsc::{Receiver, Sender};
+use tokio::sync::Mutex;
 use kvm_compose_schemas::exec::{ExecCmd, ExecCmdType, TestbedTools};
 use kvm_compose_schemas::kvm_compose_yaml::machines::GuestType;
 use crate::state::{State, StateTestbedGuest};
@@ -19,6 +21,7 @@ pub async fn prepare_guest_exec_command(
     state: &State,
     orchestration_common: &OrchestrationCommon,
     logging_send: &Sender<OrchestrationLogger>,
+    cancel_token_recv: Arc<Mutex<Receiver<()>>>,
 ) -> anyhow::Result<bool> {
 
     logging_send.send(OrchestrationLogger::info(format!("running exec {:?} on {}", exec_cmd.command_type, exec_cmd.guest_name))).await?;
@@ -45,6 +48,7 @@ pub async fn prepare_guest_exec_command(
                 &state,
                 orchestration_common,
                 &logging_send,
+                cancel_token_recv,
             ).await;
             // check command running result
             match cmd_res {
@@ -73,6 +77,7 @@ pub async fn run_guest_exec_cmd(
     _state: &State,
     orchestration_common: &OrchestrationCommon,
     logging_send: &Sender<OrchestrationLogger>,
+    cancel_token_recv: Arc<Mutex<Receiver<()>>>,
 ) -> anyhow::Result<bool> {
     check_command_on_guest_type(guest_data, exec_cmd)?;
 
@@ -143,7 +148,7 @@ pub async fn run_guest_exec_cmd(
                 }
                 TestbedTools::TLSIntercept(command) => {
                     tracing::info!("Running TLS interceptor");
-                    android::tls_intercept(&namespace, &command.command, &logging_send).await?;
+                    android::tls_intercept(&namespace, &command.command, &logging_send, cancel_token_recv).await?;
                 }
                 TestbedTools::TestPrivacy(command) => {
                     tracing::info!("Running all privacy tests");

--- a/kvm-compose/kvm-compose/src/orchestration/api.rs
+++ b/kvm-compose/kvm-compose/src/orchestration/api.rs
@@ -1,9 +1,11 @@
 use std::path::PathBuf;
+use std::sync::Arc;
 use anyhow::{anyhow, bail, Context};
 use futures_util::future::join_all;
 use nix::unistd::{Gid, Uid};
 use serde::{Deserialize, Serialize};
-use tokio::sync::mpsc::Sender;
+use tokio::sync::mpsc::{Receiver, Sender};
+use tokio::sync::Mutex;
 use kvm_compose_schemas::cli_models::{AnalysisToolsCmd, AnalysisToolsSubCmd, SnapshotSubCommand};
 use kvm_compose_schemas::deployment_models::{Deployment, DeploymentCommand};
 use kvm_compose_schemas::exec::ExecCmd;
@@ -49,8 +51,14 @@ pub struct OrchestrationProtocol {
 
 impl OrchestrationProtocol {
     /// Run all instructions in this protocol
-    pub async fn run(&self, state: &State, common: &OrchestrationCommon, logging_send: &Sender<OrchestrationLogger>) -> anyhow::Result<OrchestrationProtocolResponse> {
-        self.instruction.run(state, common, &logging_send).await
+    pub async fn run(
+        &self,
+        state: &State,
+        common: &OrchestrationCommon,
+        logging_send: &Sender<OrchestrationLogger>,
+        cancel_token_recv: Arc<Mutex<Receiver<()>>>,
+    ) -> anyhow::Result<OrchestrationProtocolResponse> {
+        self.instruction.run(state, common, &logging_send, cancel_token_recv).await
     }
 
     /// Run only for init without state
@@ -239,7 +247,8 @@ impl OrchestrationInstruction {
         &self,
         state: &State,
         orchestration_common: &OrchestrationCommon,
-        logging_send: &Sender<OrchestrationLogger>
+        logging_send: &Sender<OrchestrationLogger>,
+        cancel_token_recv: Arc<Mutex<Receiver<()>>>,
     ) -> anyhow::Result<OrchestrationProtocolResponse> {
         let protocol_response = match self {
             OrchestrationInstruction::Init { .. } => bail!("Sent an Init instruction after an Init has already been sent"),
@@ -571,7 +580,7 @@ impl OrchestrationInstruction {
             OrchestrationInstruction::AnalysisTool(at) => {
                 let analysis_tool_res = match at.tool {
                     AnalysisToolsSubCmd::TcpDump { .. } => {
-                        packet_capture(at).await
+                        packet_capture(at, cancel_token_recv).await
                     }
                 };
                 match analysis_tool_res {
@@ -588,7 +597,14 @@ impl OrchestrationInstruction {
             }
             OrchestrationInstruction::Exec(exec_cmd) => {
 
-                match prepare_guest_exec_command(&orchestration_common.project_name, exec_cmd, &state, &orchestration_common, &logging_send).await {
+                match prepare_guest_exec_command(
+                    &orchestration_common.project_name,
+                    exec_cmd,
+                    &state,
+                    &orchestration_common,
+                    &logging_send,
+                    cancel_token_recv,
+                ).await {
                     Ok(success) => {
                         let message = if success {
                             format!("Exec command {:?} succeeded", exec_cmd.command_type)

--- a/kvm-compose/kvm-compose/src/orchestration/orchestrator.rs
+++ b/kvm-compose/kvm-compose/src/orchestration/orchestrator.rs
@@ -13,6 +13,7 @@ use crate::orchestration::api::{OrchestrationInstruction, OrchestrationProtocol}
 use crate::orchestration::websocket::{send_orchestration_instruction_over_channel};
 use crate::state::orchestration_tasks::ovn_network::reapply_acl_action;
 
+#[derive(Debug)]
 pub struct CommandResult {
     pub deployment: Deployment,
     pub command_success: bool,

--- a/kvm-compose/kvm-compose/src/orchestration/websocket.rs
+++ b/kvm-compose/kvm-compose/src/orchestration/websocket.rs
@@ -214,39 +214,40 @@ pub async fn future_loop(
     orchestration_message_cmd_receiver_thread: JoinHandle<Result<(), Error>>,
     orchestration_interrupt_listener: JoinHandle<Result<(), Error>>
 ) -> anyhow::Result<CommandResult> {
-    // TODO - remove the loop and change to something more CPU friendly ... so this would be
-    //  orchestration_cmd_generation_thread & orchestration_message_cmd_receiver_thread in a
-    //  spawn() so that we can then use select! to join on either
-    //  orchestration_interrupt_listener or the new spawn that combines the two
-    loop {
-        if orchestration_interrupt_listener.is_finished() {
-            // caught interrupt, abort the others
-            orchestration_cmd_generation_thread.abort();
-            orchestration_interrupt_listener.abort();
 
-            orchestration_message_cmd_receiver_thread
-                .await
-                .context("waiting for server to process close request")?
-                .context("orchestration message thread exited")?;
+    // Here we join together the cmd generation and cmd receiver handles into a single future.
+    // This means we can await for both inside this future, and then wait on this single future
+    // in the select! macro. So we can test for if both have finished, or the cancel interrupt
+    // handler has finished first.
+
+    let both_handlers = tokio::spawn(async {
+        let (res, _) = tokio::join!(orchestration_cmd_generation_thread, orchestration_message_cmd_receiver_thread);
+        res?
+    });
+    let both_handlers_abort_handle = both_handlers.abort_handle();
+    let orchestration_interrupt_listener_abort_handle = orchestration_interrupt_listener.abort_handle();
+
+    tokio::select! {
+        _ = orchestration_interrupt_listener => {
+            // caught interrupt, abort the others
+            both_handlers_abort_handle.abort();
 
             bail!("orchestration interrupted");
         }
-        if orchestration_cmd_generation_thread.is_finished() && orchestration_message_cmd_receiver_thread.is_finished() {
+        result = both_handlers => {
             // orchestration is finished and we have finished sending messages to the server,
             // abort the interrupt listener
             tracing::debug!("cmd gen and msg gen finished, aborting interrupt listener");
-            orchestration_interrupt_listener.abort();
-            tracing::debug!("awaiting on cmd gen");
-            let result = orchestration_cmd_generation_thread.await?;
-            tracing::debug!("awaiting on msg gen");
-            let cmd_run_result = orchestration_message_cmd_receiver_thread.await?;
-            cmd_run_result?;
-            return result;
-        }
-        // TODO - what if either orchestration_cmd_generation_thread or orchestration_message_cmd_receiver_thread never finishes?
+            orchestration_interrupt_listener_abort_handle.abort();
 
-        // TODO - what if the CMD generation thread has not finished generating?
+            result?
+        }
     }
+
+    // TODO - what if either orchestration_cmd_generation_thread or orchestration_message_cmd_receiver_thread never finishes?
+
+    // TODO - what if the CMD generation thread has not finished generating?
+
 }
 
 pub async fn send_orchestration_instruction_over_channel(

--- a/kvm-compose/kvm-compose/src/orchestration/websocket.rs
+++ b/kvm-compose/kvm-compose/src/orchestration/websocket.rs
@@ -1,5 +1,4 @@
 use std::sync::Arc;
-use std::time::Duration;
 use anyhow::{bail, Context, Error};
 use futures_util::stream::{SplitSink, SplitStream};
 use futures_util::{SinkExt, StreamExt};
@@ -8,9 +7,7 @@ use tokio::sync::{mpsc, Mutex};
 use tokio::sync::mpsc::{Sender};
 use tokio::task::JoinHandle;
 use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
-use tokio_tungstenite::tungstenite::{Message, Utf8Bytes};
-use tokio_tungstenite::tungstenite::protocol::CloseFrame;
-use tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode;
+use tokio_tungstenite::tungstenite::{Message};
 use kvm_compose_schemas::cli_models::Opts;
 use kvm_compose_schemas::deployment_models::{Deployment, DeploymentCommand};
 use crate::orchestration::api::{OrchestrationInstruction, OrchestrationLogger, OrchestrationLoggerLevel, OrchestrationProtocol, OrchestrationProtocolResponse};

--- a/kvm-compose/kvm-compose/src/orchestration/websocket.rs
+++ b/kvm-compose/kvm-compose/src/orchestration/websocket.rs
@@ -60,7 +60,7 @@ pub async fn ws_orchestration_client(
     let (orchestration_send, mut orchestration_recv) = mpsc::channel(32);
 
     // start orchestration task
-    let run_orchestration_res = tokio::spawn(async move {
+    let run_orchestration_res: anyhow::Result<anyhow::Result<bool>> = tokio::spawn(async move {
 
         let local_deployment = deployment.clone();
         // let mut orchestration_recv_resub = orchestration_recv.resubscribe();
@@ -103,6 +103,14 @@ pub async fn ws_orchestration_client(
                             // if command generation end is matched, then we can stop checking for
                             // more commands and continue to wait for the server to finish if the
                             // last sent command is long-running and/or will send more logging
+
+                            // we need to send the End command still
+                            send_orchestration_instruction(
+                                websocket_container_sender_clone.clone(), // this is cloned every loop...
+                                websocket_container_receiver_clone.clone(),
+                                protocol,
+                            ).await?;
+
                             break;
                         }
                         _ => {}
@@ -144,8 +152,6 @@ pub async fn ws_orchestration_client(
                 .await
                 .context("sending serialised OrchestrationProtocol")?;
 
-            tokio::time::sleep(Duration::from_secs(5)).await;
-
             bail!("orchestration was interrupted by user")
 
         });
@@ -154,28 +160,32 @@ pub async fn ws_orchestration_client(
         // but we need to make sure to abort all the futures once we are done.
 
         // this will check each of the three async tasks to see which has finished first
-        let deployment_result = tokio::spawn(future_loop(
+        let clientside_cmd_result = tokio::spawn(future_loop(
             orchestration_cmd_generation_thread,
             orchestration_message_cmd_receiver_thread,
             orchestration_interrupt_listener,
         )).await.context("running parallel tasks to manage command running state")?;
-        let success = match deployment_result {
+        // this checks whether the client side was successful or not i.e. the command generation
+        // and/or sending to the server could have worked or failed, but this is separate to
+        // whether the commands actually worked on the server - we need to get this state back from
+        // the server next
+        let client_success = match clientside_cmd_result {
+            // the command didn't error but the command could be success: true or false
             Ok(cmd_res) => cmd_res.command_success,
             Err(err) => {
-                bail!(err); // TODO - we should close the websocket before bailing
+                tracing::error!("command error: {}", err);
+                false
             },
         };
 
-        // close websocket
-        tracing::debug!("closing websocket");
-        let _ = safe_sender.lock()
-                .await
-                .send(Message::Close(Some(CloseFrame {
-            code: CloseCode::Normal,
-            reason: Utf8Bytes::from("End of orchestration"),
-        }))).await.context("sending close message to orchestration worker")?;
+        // TODO - wait for state of completion of the command from server, if nothing comes back
+        //  in X amount of time, then we give this result to the user as well
 
-        Ok(success)
+        tracing::debug!("waiting for server final response");
+        let server_success = final_server_response(safe_receiver).await?;
+
+        // both must be successful
+        Ok(client_success && server_success)
     })
         .await
         .context("spawning send receive task for client");
@@ -398,4 +408,52 @@ async fn send_orchestration_instruction(
 
 
     Ok(())
+}
+
+async fn final_server_response(
+    safe_receiver: Arc<Mutex<SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>>>
+) -> anyhow::Result<bool> {
+
+    let message = safe_receiver
+        .lock()
+        .await
+        .next()
+        .await;
+
+    if let Some(Ok(final_response)) = message {
+        match final_response {
+            Message::Text(b) => {
+                let response_result: Result<OrchestrationProtocolResponse, serde_json::Error> = serde_json::from_str(&b);
+                if let Ok(ref response) = response_result {
+                    let result_messages = response.get_result_messages()?;
+                    if let Some(success) = result_messages.success_message {
+                        for msg in success {
+                            tracing::info!("Server response: {}", msg);
+                        }
+                        return Ok(true);
+                    }
+                    if let Some(fail) = result_messages.fail_message {
+                        // tracing::error!("Instruction completed with the following failures: {}", fail);
+                        for msg in fail {
+                            tracing::error!("Server response: {}", msg);
+                        }
+                        return Ok(false);
+                    }
+                    // TODO - logic here can be improved, this doesn't correspond to anything
+                    Ok(false)
+                } else {
+                    // we couldn't get the final response
+                    tracing::error!("could not deserialise the last response from the server");
+                    Ok(false)
+                }
+            }
+            _ => {
+                tracing::error!("received unexpected response format from server when waiting for final message");
+                Ok(false)
+            }
+        }
+    } else {
+        tracing::error!("received unexpected response from server when waiting for final message");
+        Ok(false)
+    }
 }

--- a/kvm-compose/kvm-compose/src/orchestration/websocket.rs
+++ b/kvm-compose/kvm-compose/src/orchestration/websocket.rs
@@ -7,7 +7,9 @@ use tokio::sync::{mpsc, Mutex};
 use tokio::sync::mpsc::{Sender};
 use tokio::task::JoinHandle;
 use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
-use tokio_tungstenite::tungstenite::{Message};
+use tokio_tungstenite::tungstenite::{Message, Utf8Bytes};
+use tokio_tungstenite::tungstenite::protocol::CloseFrame;
+use tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode;
 use kvm_compose_schemas::cli_models::Opts;
 use kvm_compose_schemas::deployment_models::{Deployment, DeploymentCommand};
 use crate::orchestration::api::{OrchestrationInstruction, OrchestrationLogger, OrchestrationLoggerLevel, OrchestrationProtocol, OrchestrationProtocolResponse};
@@ -115,11 +117,12 @@ pub async fn ws_orchestration_client(
                     // send protocol to server on websocket, this will then wait for the
                     // acknowledgement of receipt, any logging and then the instruction complete
                     // response
-                    send_orchestration_instruction(
+                    let instruction_res = send_orchestration_instruction(
                         websocket_container_sender_clone.clone(), // this is cloned every loop...
                         websocket_container_receiver_clone.clone(),
                         protocol,
-                    ).await?;
+                    ).await;
+                    instruction_res?;
                     
                 } else {
                     bail!("exiting socket send loop, message not Ok");
@@ -178,8 +181,22 @@ pub async fn ws_orchestration_client(
         // TODO - wait for state of completion of the command from server, if nothing comes back
         //  in X amount of time, then we give this result to the user as well
 
+        // if we had a client failure, then we need to tell the server to stop because the client
+        // will not be continuing with this command running session
+        if !client_success {
+            tracing::info!("Client experienced an error, closing connection to server");
+            // to stop we send a close message, which will be handled by the
+            // `server_listener_handler` and `process_message` on the server-side
+            let _ = safe_sender.lock().await.send(Message::Close(Some(CloseFrame {
+                code: CloseCode::Error, // this is error
+                reason: Utf8Bytes::from("Could not deserialise the Init instruction"),
+            }))).await.context("sending close to client websocket")?;
+            return Ok(false);
+        }
         tracing::debug!("waiting for server final response");
         let server_success = final_server_response(safe_receiver).await?;
+
+        tracing::debug!("server_success: {server_success:?}");
 
         // both must be successful
         Ok(client_success && server_success)
@@ -217,8 +234,8 @@ pub async fn ws_orchestration_client(
 /// the command running. The command running consists of the command generator and the command
 /// sender.
 pub async fn future_loop(
-    orchestration_cmd_generation_thread: JoinHandle<Result<CommandResult, Error>>,
-    orchestration_message_cmd_receiver_thread: JoinHandle<Result<(), Error>>,
+    mut orchestration_cmd_generation_thread: JoinHandle<Result<CommandResult, Error>>,
+    mut orchestration_message_cmd_receiver_thread: JoinHandle<Result<(), Error>>,
     orchestration_interrupt_listener: JoinHandle<Result<(), Error>>
 ) -> anyhow::Result<CommandResult> {
 
@@ -228,8 +245,59 @@ pub async fn future_loop(
     // handler has finished first.
 
     let both_handlers = tokio::spawn(async {
-        let (res, _) = tokio::join!(orchestration_cmd_generation_thread, orchestration_message_cmd_receiver_thread);
-        res?
+        // Here we have a mildly complicated set of exit conditions, because the command generation
+        // will finish before the other one naturally. However, if the command runner future fails
+        // then we want to abort command generation. If command generation fails, then we want to
+        // abort the command running (lets be on the safe side). So we need to poll both and check
+        // for their outcomes.
+
+        tokio::select! {
+            cmd_gen_result = &mut orchestration_cmd_generation_thread => {
+                match cmd_gen_result {
+                    Ok(Ok(cmd_res)) => {
+                        // cmd gen finished, just wait for cmd run to finish
+                        tracing::info!("Command generation finished");
+                        orchestration_message_cmd_receiver_thread.await??;
+                        Ok(cmd_res)
+                    },
+                    Ok(Err(err)) => {
+                        // cmd gen failed, so we abort cmd run
+                        tracing::error!("Command generation finished due to error: {err:#}");
+                        orchestration_message_cmd_receiver_thread.abort();
+                        // TODO - send cancel token?
+                        Err(err)
+                    }
+                    Err(join_err) => {
+                        // cmd gen (outer) future panicked, so also abort cmd run
+                        tracing::error!("Command generation failed due to error {join_err:#}");
+                        orchestration_message_cmd_receiver_thread.abort();
+                        Err(join_err.into())
+                    }
+                }
+            }
+            cmd_run_result = &mut orchestration_message_cmd_receiver_thread => {
+                match cmd_run_result {
+                    Ok(Ok(_)) => {
+                        // cmd running finished, we expect cmd gen to have already finished
+                        let cmd_res = orchestration_cmd_generation_thread.await??;
+                        tracing::info!("Command running finished");
+                        Ok(cmd_res)
+                    }
+                    Ok(Err(err)) => {
+                        // cmd running aborted due to error, so kill cmd gen
+                        tracing::error!("Command running finished due to error: {err:#}");
+                        orchestration_cmd_generation_thread.abort();
+                        Err(err)
+                    }
+                    Err(join_err) => {
+                        // cmd run failed to join due to a panic, fail everything
+                        tracing::error!("Command running failed due to error {join_err:#}");
+                        orchestration_cmd_generation_thread.abort();
+                        Err(join_err.into())
+                    }
+                }
+            }
+        }
     });
     let both_handlers_abort_handle = both_handlers.abort_handle();
     let orchestration_interrupt_listener_abort_handle = orchestration_interrupt_listener.abort_handle();

--- a/kvm-compose/kvm-compose/src/orchestration/websocket.rs
+++ b/kvm-compose/kvm-compose/src/orchestration/websocket.rs
@@ -188,8 +188,8 @@ pub async fn ws_orchestration_client(
             // to stop we send a close message, which will be handled by the
             // `server_listener_handler` and `process_message` on the server-side
             let _ = safe_sender.lock().await.send(Message::Close(Some(CloseFrame {
-                code: CloseCode::Error, // this is error
-                reason: Utf8Bytes::from("Could not deserialise the Init instruction"),
+                code: CloseCode::Error,
+                reason: Utf8Bytes::from("There was an error in command running"),
             }))).await.context("sending close to client websocket")?;
             return Ok(false);
         }

--- a/kvm-compose/kvm-compose/src/orchestration/websocket.rs
+++ b/kvm-compose/kvm-compose/src/orchestration/websocket.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Duration;
 use anyhow::{bail, Context, Error};
 use futures_util::stream::{SplitSink, SplitStream};
 use futures_util::{SinkExt, StreamExt};
@@ -15,10 +16,6 @@ use kvm_compose_schemas::deployment_models::{Deployment, DeploymentCommand};
 use crate::orchestration::api::{OrchestrationInstruction, OrchestrationLogger, OrchestrationLoggerLevel, OrchestrationProtocol, OrchestrationProtocolResponse};
 use crate::orchestration::orchestrator::{run_orchestration, CommandResult};
 
-struct WebsocketContainer {
-    pub sender: SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, Message>,
-    pub receiver: SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>,
-}
 
 /// This function completely handles the orchestration command from the client side by sending instructions to the
 /// server. We pass the websocket sink and stream to the orchestration function, and depending on the orchestration
@@ -49,9 +46,13 @@ pub async fn ws_orchestration_client(
     let (sender, receiver) = ws_stream.split();
     // since we move this sender and received into the futures below, we need to wrap these in a thread safe
     // container so that we can clone the container and re-use it later
-    let websocket_container = Arc::new(Mutex::new(WebsocketContainer { sender, receiver }));
+    let safe_sender = Arc::new(Mutex::new(sender));
+    let safe_receiver = Arc::new(Mutex::new(receiver));
     // make a copy for the futures
-    let websocket_container_clone = websocket_container.clone();
+    let websocket_container_sender_clone = safe_sender.clone();
+    let websocket_container_receiver_clone = safe_receiver.clone();
+
+    let cancellation_future_ws_sender_clone = safe_sender.clone();
 
     // when using MPSC channel, the sender will wait until the buffer is read, so it shouldn't
     // matter if the sender works faster than the receiver and therefore the size of the buffer
@@ -106,9 +107,12 @@ pub async fn ws_orchestration_client(
                         }
                         _ => {}
                     }
-                    // send protocol to server on websocket
+                    // send protocol to server on websocket, this will then wait for the
+                    // acknowledgement of receipt, any logging and then the instruction complete
+                    // response
                     send_orchestration_instruction(
-                        websocket_container_clone.clone(), // this is cloned every loop...
+                        websocket_container_sender_clone.clone(), // this is cloned every loop...
+                        websocket_container_receiver_clone.clone(),
                         protocol,
                     ).await?;
                     
@@ -126,6 +130,21 @@ pub async fn ws_orchestration_client(
             let _ = tokio::signal::ctrl_c().await;
 
             tracing::info!("captured ctrl + C, gracefully stopping command");
+
+            // create and send the cancel token to the server, before this exits in the future loop
+            // which will abort the other tasks
+            let cancel = serde_json::to_vec(&OrchestrationProtocol {
+                instruction: OrchestrationInstruction::Cancel,
+            }).context("serializing cancel instruction")?;
+
+            cancellation_future_ws_sender_clone
+                .lock()
+                .await
+                .send(Message::Binary(cancel.into()))
+                .await
+                .context("sending serialised OrchestrationProtocol")?;
+
+            tokio::time::sleep(Duration::from_secs(5)).await;
 
             bail!("orchestration was interrupted by user")
 
@@ -149,9 +168,8 @@ pub async fn ws_orchestration_client(
 
         // close websocket
         tracing::debug!("closing websocket");
-        let _ = websocket_container.lock()
+        let _ = safe_sender.lock()
                 .await
-                .sender
                 .send(Message::Close(Some(CloseFrame {
             code: CloseCode::Normal,
             reason: Utf8Bytes::from("End of orchestration"),
@@ -196,12 +214,21 @@ pub async fn future_loop(
     orchestration_message_cmd_receiver_thread: JoinHandle<Result<(), Error>>,
     orchestration_interrupt_listener: JoinHandle<Result<(), Error>>
 ) -> anyhow::Result<CommandResult> {
+    // TODO - remove the loop and change to something more CPU friendly ... so this would be
+    //  orchestration_cmd_generation_thread & orchestration_message_cmd_receiver_thread in a
+    //  spawn() so that we can then use select! to join on either
+    //  orchestration_interrupt_listener or the new spawn that combines the two
     loop {
         if orchestration_interrupt_listener.is_finished() {
             // caught interrupt, abort the others
             orchestration_cmd_generation_thread.abort();
-            orchestration_message_cmd_receiver_thread.abort();
             orchestration_interrupt_listener.abort();
+
+            orchestration_message_cmd_receiver_thread
+                .await
+                .context("waiting for server to process close request")?
+                .context("orchestration message thread exited")?;
+
             bail!("orchestration interrupted");
         }
         if orchestration_cmd_generation_thread.is_finished() && orchestration_message_cmd_receiver_thread.is_finished() {
@@ -242,7 +269,8 @@ pub async fn send_orchestration_instruction_over_channel(
 /// server to process. This protocol is split into three parts on the client side: 1) send 2) receive acknowledgement
 /// 3) wait for response of outcome of instruction. The outcome may or may not have been successful.
 async fn send_orchestration_instruction(
-    websocket_container: Arc<Mutex<WebsocketContainer>>,
+    websocket_sender: Arc<Mutex<SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, Message>>>,
+    websocket_receiver: Arc<Mutex<SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>>>,
     orchestration_protocol: OrchestrationProtocol,
 ) -> anyhow::Result<()> {
 
@@ -251,19 +279,17 @@ async fn send_orchestration_instruction(
     // need to serialise the instruction to binary format
     let serialised_instruction = serde_json::to_vec(&orchestration_protocol)
         .context("serialising OrchestrationProtocol")?;
-    let _ = websocket_container
+    let _ = websocket_sender
         .lock()
         .await
-        .sender
         .send(Message::Binary(serialised_instruction.into()))
         .await
         .context("sending serialised OrchestrationProtocol")?;
 
     // get acknowledgement
-    if let Some(response) = websocket_container
+    if let Some(response) = websocket_receiver
         .lock()
         .await
-        .receiver
         .next()
         .await {
         let response = response
@@ -295,10 +321,9 @@ async fn send_orchestration_instruction(
     loop {
 
         // wait for response
-        if let Some(response) = websocket_container
+        if let Some(response) = websocket_receiver
             .lock()
             .await
-            .receiver
             .next().await {
             let response = response
                 .context("getting instruction outcome response")?;

--- a/kvm-compose/kvm-compose/src/server_web_client/client.rs
+++ b/kvm-compose/kvm-compose/src/server_web_client/client.rs
@@ -73,7 +73,7 @@ pub async fn orchestration_action(
             success
         }
         Err(err) => {
-            tracing::error!("there was a problem in the orchestration, will stop");
+            tracing::error!("there was a problem in the command running, will stop");
             err.chain().for_each(|cause| tracing::error!("because: {}", cause));
             false
         }

--- a/kvm-compose/kvm-compose/src/server_web_client/client.rs
+++ b/kvm-compose/kvm-compose/src/server_web_client/client.rs
@@ -86,14 +86,6 @@ pub async fn orchestration_action(
     // TODO - make sure the database update matches result?
     tracing::debug!("deployment is now in {:?} state", &check_deployment.state);
 
-    // // only bail if the command wasn't successful, despite the state of the deployment being failed
-    // // .. this is because not all commands impact the deployment state i.e. exec commands
-    // if !success {
-    //     // return the result of this command
-    //     get_result(&check_deployment.state)
-    //         .context("getting orchestration result")?;
-    // }
-
     if success {
         Ok(())
     } else {
@@ -157,20 +149,6 @@ async fn analysis_tools_action(
 ) -> anyhow::Result<()> {
 
     Ok(())
-}
-
-/// Helper to check the resulting state from the command running on the testbed server and then
-/// return Ok or panic with helpful context
-fn get_result(
-    deployment_end_state: &DeploymentState,
-) -> anyhow::Result<()> {
-    match deployment_end_state {
-        DeploymentState::Failed(dep_cmd) => bail!("the command {:?} was not successful", dep_cmd),
-        _ => {
-            tracing::info!("the command was successful");
-            Ok(())
-        }
-    }
 }
 
 /// Prevent commands running in a folder with the same name as an existing deployment, which would

--- a/kvm-compose/kvm-compose/src/server_web_client/client.rs
+++ b/kvm-compose/kvm-compose/src/server_web_client/client.rs
@@ -86,15 +86,20 @@ pub async fn orchestration_action(
     // TODO - make sure the database update matches result?
     tracing::debug!("deployment is now in {:?} state", &check_deployment.state);
 
-    // only bail if the command wasn't successful, despite the state of the deployment being failed
-    // .. this is because not all commands impact the deployment state i.e. exec commands
-    if !success {
-        // return the result of this command
-        get_result(&check_deployment.state)
-            .context("getting orchestration result")?;
+    // // only bail if the command wasn't successful, despite the state of the deployment being failed
+    // // .. this is because not all commands impact the deployment state i.e. exec commands
+    // if !success {
+    //     // return the result of this command
+    //     get_result(&check_deployment.state)
+    //         .context("getting orchestration result")?;
+    // }
+
+    if success {
+        Ok(())
+    } else {
+        bail!("Server reported command failure")
     }
 
-    Ok(())
 }
 
 pub fn get_deployment_action(

--- a/kvm-compose/testbedos-server/src/orchestration/websocket.rs
+++ b/kvm-compose/testbedos-server/src/orchestration/websocket.rs
@@ -198,6 +198,9 @@ async fn run(
         // channel for the client listener loop to place the instructions for processing
         let (instruction_send_channel, mut instruction_recv_channel) = mpsc::channel(32);
         // channel to control cancellation, to be read at the point of where the commands are being run
+        // ... this is mostly important for implementing custom cancel behaviours, beyond stop
+        // accepting any further instructions. since most of the testbed instructions are short
+        // we can accept when we cancel, the current command will finish
         let (cancel_send_channel, cancel_recv_channel) = mpsc::channel(32);
         let safe_cancel_recv_channel = Arc::new(Mutex::new(cancel_recv_channel));
 

--- a/kvm-compose/testbedos-server/src/orchestration/websocket.rs
+++ b/kvm-compose/testbedos-server/src/orchestration/websocket.rs
@@ -1,3 +1,4 @@
+use std::fmt::format;
 use std::sync::Arc;
 use anyhow::{bail, Context};
 use axum::extract::ws::{CloseFrame, Message, Utf8Bytes, WebSocket};
@@ -156,9 +157,10 @@ async fn run(
     let deployment_command_copy = deployment_command.clone();
     let deployment_copy = deployment.clone();
     let db_config_copy = db_config.clone();
+    let sender_clone = sender.clone();
 
     // in this loop, we wait for instructions until the client sends a close
-    let orchestration_task: anyhow::Result<()> = tokio::spawn(async move {
+    let orchestration_task: anyhow::Result<anyhow::Result<bool>> = tokio::spawn(async move {
 
         tracing::info!("getting project state");
         // get some of the deployment specific data to be used later
@@ -192,8 +194,8 @@ async fn run(
 
         tracing::info!("starting the orchestration listen loop");
 
-
-        // DEBUG
+        // we record whether an instruction was cancelled, to be handled later
+        let mut cancelled = false;
 
         // channel for the client listener loop to place the instructions for processing
         let (instruction_send_channel, mut instruction_recv_channel) = mpsc::channel(32);
@@ -206,8 +208,8 @@ async fn run(
 
         // server listener loop, handling the instructions sent from the client, which then checks
         // to run an instruction, cancel or close the connection
-        let server_listener_handler_sender = sender.clone();
-        let server_listener_handler: JoinHandle<anyhow::Result<_>> = tokio::spawn(async move {
+        let server_listener_handler_sender = sender_clone.clone();
+        let server_listener_handler: JoinHandle<anyhow::Result<bool>> = tokio::spawn(async move {
             loop {
 
                 // get message from server
@@ -225,11 +227,23 @@ async fn run(
                             match instruction.instruction {
                                 OrchestrationInstruction::Cancel => {
                                     cancel_send_channel.send(()).await.context("sending cancel signal")?;
+                                    // set cancel bool to true to change outcome of run
+                                    cancelled = true;
                                     // exit this loop as we will not be receiving any more messages from client
                                     break;
                                 }
+                                OrchestrationInstruction::End => {
+                                    instruction_send_channel
+                                        .send(Some(instruction))
+                                        .await
+                                        .context("sending end instruction")?;
+                                    break;
+                                }
                                 _ => {
-                                    instruction_send_channel.send(Some(instruction)).await.context("sending cancel instruction")?;
+                                    instruction_send_channel
+                                        .send(Some(instruction))
+                                        .await
+                                        .context("sending instruction")?;
                                 }
                             }
                         }
@@ -255,6 +269,7 @@ async fn run(
                     }
 
                 } else {
+                    tracing::error!("Could not process the clients instruction, ending command running");
                     let _ = server_listener_handler_sender.lock().await.send(Message::Close(Some(CloseFrame {
                         code: 1011,
                         reason: Utf8Bytes::from("The server could not process the last message, connection closed"),
@@ -264,11 +279,11 @@ async fn run(
                 }
 
             }
-            Ok(())
+            Ok(cancelled)
         });
 
         // server instruction handler loop, processing the instructions parsed by the server listener loop
-        let server_instruction_handler_sender = sender.clone();
+        let server_instruction_handler_sender = sender_clone.clone();
         let server_instruction_handler: JoinHandle<anyhow::Result<_>> = tokio::spawn(async move {
 
             // loop through all the messages sent to the channel, placed by the future working with
@@ -337,74 +352,140 @@ async fn run(
         });
 
         // await on both so that we don't continue before both have finished
-        let _ = tokio::try_join!(server_listener_handler, server_instruction_handler)?;
+        let (cancelled, _) = tokio::try_join!(server_listener_handler, server_instruction_handler)?;
 
-        tracing::info!("end of orchestration connection");
+        tracing::info!("end of command running");
 
-        Ok(())
+        Ok(cancelled)
 
     }).await.context("could not join on job task")?;
 
     // TODO - is there a chance of a race condition between this running and the client checking for the outcome?
     //  it would be in "running" state if the client checks before the server gets a chance
 
-    // determine the outcome of the job
-    match orchestration_task {
-        Ok(_) => {
-            // get deployment config and set to success for whatever the command was
-            match deployment_command {
-                DeploymentCommand::Up { .. } => {
-                    deployment.state = DeploymentState::Up;
-                    db_config.deployment_config_db
-                        .write()
-                        .await
-                        .update_deployment(deployment.name.clone(), deployment)
-                        .await
-                        .context("updating deployment to up state")?;
+    tracing::info!("end of command running, now determining if it was successful");
+
+    // determine the outcome of the job, first we need to check if we managed to join on the job
+    let was_cancelled = match orchestration_task {
+        Ok(job_result) => {
+            // job was okay, now process the result which contains whether it was cancelled or not
+            match job_result {
+                Ok(cancelled) => {
+                    // get deployment config and set to success for whatever the command was
+                    match deployment_command {
+                        DeploymentCommand::Up { .. } => {
+                            deployment.state = if cancelled {
+                                DeploymentState::Failed(deployment_command)
+                            } else {
+                                DeploymentState::Up
+                            };
+                            deployment = db_config.deployment_config_db
+                                .write()
+                                .await
+                                .update_deployment(deployment.name.clone(), deployment)
+                                .await
+                                .context("updating deployment to up state")?;
+                        }
+                        DeploymentCommand::Down => {
+                            deployment.state = if cancelled {
+                                DeploymentState::Failed(deployment_command)
+                            } else {
+                                DeploymentState::Down
+                            };
+                            deployment = db_config.deployment_config_db
+                                .write()
+                                .await
+                                .update_deployment(deployment.name.clone(), deployment)
+                                .await
+                                .context("updating deployment to down state")?;
+                        }
+                        DeploymentCommand::ClearArtefacts => {
+                            // should be down due to clear artefacts implementation
+                            deployment.state = if cancelled {
+                                DeploymentState::Failed(deployment_command)
+                            } else {
+                                DeploymentState::Down
+                            };
+                            deployment = db_config.deployment_config_db
+                                .write()
+                                .await
+                                .update_deployment(deployment.name.clone(), deployment)
+                                .await
+                                .context("updating deployment to down state")?;
+                        }
+                        _ => {
+                            // set to previous state
+                            deployment.state = previous_state;
+                            deployment = db_config.deployment_config_db
+                                .write()
+                                .await
+                                .update_deployment(deployment.name.clone(), deployment)
+                                .await
+                                .context("updating deployment to previous state")?;
+                        }
+                    }
+                    // return whether it was cancelled or not
+                    Some(cancelled)
                 }
-                DeploymentCommand::Down => {
-                    deployment.state = DeploymentState::Down;
-                    db_config.deployment_config_db
+                Err(err) => {
+                    // we could join on the job, but there was an error in the run
+                    tracing::error!("the job did not finish successfully: {err:#}");
+                    deployment.state = DeploymentState::Failed(deployment_command);
+                    deployment = db_config.deployment_config_db
                         .write()
                         .await
                         .update_deployment(deployment.name.clone(), deployment)
                         .await
-                        .context("updating deployment to down state")?;
-                }
-                DeploymentCommand::ClearArtefacts => {
-                    // should be down due to clear artefacts implementation
-                    deployment.state = DeploymentState::Down;
-                    db_config.deployment_config_db
-                        .write()
-                        .await
-                        .update_deployment(deployment.name.clone(), deployment)
-                        .await
-                        .context("updating deployment to down state")?;
-                }
-                _ => {
-                    // set to previous state
-                    deployment.state = previous_state;
-                    db_config.deployment_config_db
-                        .write()
-                        .await
-                        .update_deployment(deployment.name.clone(), deployment)
-                        .await
-                        .context("updating deployment to previous state")?;
+                        .context("updating deployment to failed state")?;
+                    None
                 }
             }
         }
         Err(err) => {
+            // we could not join on the job, so there was a significant error
             tracing::error!("error in orchestration websocket: {err:#}");
             // set state to failed with the deployment command attempted
             deployment.state = DeploymentState::Failed(deployment_command);
-            db_config.deployment_config_db
+            deployment = db_config.deployment_config_db
                 .write()
                 .await
                 .update_deployment(deployment.name.clone(), deployment)
                 .await
                 .context("updating deployment to failed state")?;
+            None
         }
-    }
+    };
+
+    let cancelled = match was_cancelled {
+        None => "".to_string(),
+        Some(some) => if some {
+            " and was cancelled".to_string()
+        } else {
+            "".to_string()
+        }
+    };
+    let final_response = match deployment.state {
+        DeploymentState::Failed(_) => {
+            OrchestrationProtocolResponse::Generic {
+                is_success: false,
+                message: format!("The command failed{cancelled}"),
+            }
+        }
+        _ => {
+            OrchestrationProtocolResponse::Generic {
+                is_success: true,
+                message: format!("The command was successful{cancelled}"),
+            }
+        }
+    };
+    let serialised_response = serde_json::to_string(&final_response)?;
+
+    tracing::info!("sending final message to client with result");
+
+    // finally send to the client the result
+    let _ = sender.lock().await.send(Message::Text(serialised_response.into()))
+        .await
+        .context("sending instruction result")?;
 
     Ok(())
 }

--- a/kvm-compose/testbedos-server/src/orchestration/websocket.rs
+++ b/kvm-compose/testbedos-server/src/orchestration/websocket.rs
@@ -4,6 +4,7 @@ use axum::extract::ws::{CloseFrame, Message, Utf8Bytes, WebSocket};
 use futures_util::{SinkExt, StreamExt};
 use futures_util::stream::SplitSink;
 use tokio::sync::{mpsc, Mutex};
+use tokio::sync::mpsc::{Receiver};
 use tokio::task::JoinHandle;
 use kvm_compose_lib::orchestration::api::{OrchestrationInstruction, OrchestrationLogger, OrchestrationProtocol, OrchestrationProtocolResponse};
 use kvm_compose_lib::orchestration::{OrchestrationCommon};
@@ -192,61 +193,149 @@ async fn run(
         tracing::info!("starting the orchestration listen loop");
 
 
-        loop {
+        // DEBUG
 
-            // make copies (new ref as it's an Arc) in the loop so that we can move them
-            let loop_state = state.clone();
-            let loop_common = common.clone();
-            let loop_sender = sender.clone();
-            let loop_sender_cancel = sender.clone();
+        // channel for the client listener loop to place the instructions for processing
+        let (instruction_send_channel, mut instruction_recv_channel) = mpsc::channel(32);
+        // channel to control cancellation, to be read at the point of where the commands are being run
+        let (cancel_send_channel, cancel_recv_channel) = mpsc::channel(32);
+        let safe_cancel_recv_channel = Arc::new(Mutex::new(cancel_recv_channel));
 
-            // get message from server
-            let raw_msg = receiver.next().await;
-            // make sure it is ok and not empty
-            if let Some(Ok(msg)) = raw_msg {
+        // server listener loop, handling the instructions sent from the client, which then checks
+        // to run an instruction, cancel or close the connection
+        let server_listener_handler_sender = sender.clone();
+        let server_listener_handler: JoinHandle<anyhow::Result<_>> = tokio::spawn(async move {
+            loop {
 
-                // now we want to execute a command based on this message, but we might also receive
-                // a cancellation token ... the receiver must be free to listen to this command ...
-                // we also do not expect any other message over the socket from the client while a
-                // command is running
+                // get message from server
+                let raw_msg = receiver.next().await;
+                if let Some(Ok(msg)) = raw_msg {
 
-                // if this errors, it is either due to orchestration failure or non cancellation
-                // token was received
-                let close_connection_bool_result = tokio::select! {
-                    // process client instruction and return whether we continue
-                    close = process_client_instruction(msg, loop_sender, loop_state, loop_common) => close,
-                    // process potential cancelation token
-                    Some(Ok(maybe_cancel_token)) = receiver.next() => process_potential_cancel_token(maybe_cancel_token, loop_sender_cancel.clone()).await
-                };
+                    tracing::info!("got message {:?}", msg);
 
-                // TODO if this result is an Err, then websocket isn't closed?
-                let close_connection_bool = close_connection_bool_result
-                    .context("determining if the orchestration loop should continue")?;
+                    // get the instruction from the message, or handle a close web socket message
+                    match process_message(msg).await.context("getting instruction from client message")? {
+                        Some(instruction) => {
+                            // we got an instruction
 
-                // got a close result, exit loop
-                if close_connection_bool {
-                    tracing::info!("close connection true in orchestration websocket");
+                            // send the instruction to the other thread or process cancel
+                            match instruction.instruction {
+                                OrchestrationInstruction::Cancel => {
+                                    cancel_send_channel.send(()).await.context("sending cancel signal")?;
+                                    // exit this loop as we will not be receiving any more messages from client
+                                    break;
+                                }
+                                _ => {
+                                    instruction_send_channel.send(Some(instruction)).await.context("sending cancel instruction")?;
+                                }
+                            }
+                        }
+                        None => {
+                            // we got a websocket close message
+                            tracing::info!("close connection true in orchestration websocket");
 
-                    // normal close
-                    // connection might already be closed by client so don't handle error with ?
-                    let _ = loop_sender_cancel.lock().await.send(Message::Close(Some(CloseFrame {
-                        code: 1000,
-                        reason: Utf8Bytes::from("Last command received, connection closed"),
-                    }))).await.context("sending close to client websocket"); // TODO - need ? here?
+                            // tell the instruction channel to close up
+                            instruction_send_channel.send(None).await.context("sending close signal to instruction_send_channel")?;
+
+                            // TODO - this following code errors because the connection is already closed on the client's side
+                            //  do we leave this in for robustness?
+
+                            // normal close
+                            // connection might already be closed by client so don't handle error with ?
+                            let _ = server_listener_handler_sender.lock().await.send(Message::Close(Some(CloseFrame {
+                                code: 1000,
+                                reason: Utf8Bytes::from("Last command received, connection closed"),
+                            }))).await.context("sending close to client websocket"); // TODO - need ? here?
+
+                            break;
+                        }
+                    }
+
+                } else {
+                    let _ = server_listener_handler_sender.lock().await.send(Message::Close(Some(CloseFrame {
+                        code: 1011,
+                        reason: Utf8Bytes::from("The server could not process the last message, connection closed"),
+                    }))).await.context("sending close to client websocket")?;
 
                     break;
                 }
 
-            } else {
-                // message from client was not Ok
-                let _ = loop_sender_cancel.lock().await.send(Message::Close(Some(CloseFrame {
-                    code: 1011,
-                    reason: Utf8Bytes::from("The server could not process the last message, connection closed"),
-                }))).await.context("sending close to client websocket")?;
-
-                break;
             }
-        }
+            Ok(())
+        });
+
+        // server instruction handler loop, processing the instructions parsed by the server listener loop
+        let server_instruction_handler_sender = sender.clone();
+        let server_instruction_handler: JoinHandle<anyhow::Result<_>> = tokio::spawn(async move {
+
+            // loop through all the messages sent to the channel, placed by the future working with
+            // the websocket to the client ... this will acknowledge the instruction back to the
+            // client and then run the command. Since the channel will only have one instruction
+            // at a time due to the protocol from the client-server only processing one instruction
+            // at a time, then when the cancel token is placed in the queue it will be immediately
+            // consumed, so that will trigger the cancel immediately
+            loop {
+                tokio::select! {
+                    Some(instruction) = instruction_recv_channel.recv() => {
+                        match instruction {
+                            Some(instruction) => {
+                                // send acknowledgement back to client
+                                let _ = server_instruction_handler_sender.lock().await.send(Message::Text("Receiving instruction OK".into()))
+                                    .await
+                                    .context("sending acknowledgement")?;
+
+                                let run_instruction_res = get_instruction_result(
+                                    instruction,
+                                    &state,
+                                    &common,
+                                    server_instruction_handler_sender.clone(),
+                                    safe_cancel_recv_channel.clone(),
+                                ).await.context("getting result for instruction execution and ws sender")?;
+
+                                // send to client the result
+                                let serialised_response = serde_json::to_string(&run_instruction_res)?;
+                                let _ = server_instruction_handler_sender.lock().await.send(Message::Text(serialised_response.into()))
+                                    .await
+                                    .context("sending instruction result")?;
+
+                                if !run_instruction_res.is_success()? {
+                                    bail!("there was a failed orchestration instruction, {run_instruction_res:?}");
+                                }
+
+                            }
+                            None => {
+                                // we got a message, but it was None, meaning there is nothing left to
+                                // send from instruction_recv_channel
+                                break;
+                            }
+                        }
+                    }
+                    // cancel_response = cancel_response_recv_channel.recv() => {
+                    //     // if there was a cancel, then there will be a response with the cancel state
+                    //     if let Some(response) = cancel_response {
+                    //
+                    //     } else {
+                    //
+                    //     }
+                    // }
+                    else => bail!("there was a problem in getting the message from the instruction_recv_channel"),
+                }
+                // if let Ok(instruction) = instruction_recv_channel.recv().await.context("receiving instruction message") {
+                //
+                //
+                // } else {
+                //     // instruction over channel was not Ok
+                //     bail!("there was a problem in getting the message from the instruction_recv_channel")
+                // }
+
+            }
+
+            Ok(())
+        });
+
+        // await on both so that we don't continue before both have finished
+        let _ = tokio::try_join!(server_listener_handler, server_instruction_handler)?;
+
         tracing::info!("end of orchestration connection");
 
         Ok(())
@@ -324,8 +413,9 @@ async fn get_instruction_result(
     instruction: OrchestrationProtocol,
     state: &State,
     common: &OrchestrationCommon,
-    ws_sender: Arc<Mutex<SplitSink<WebSocket, Message>>>
-) -> anyhow::Result<(OrchestrationProtocolResponse, Arc<Mutex<SplitSink<WebSocket, Message>>>)> {
+    ws_sender: Arc<Mutex<SplitSink<WebSocket, Message>>>,
+    cancel_token_recv: Arc<Mutex<Receiver<()>>>,
+) -> anyhow::Result<OrchestrationProtocolResponse> {
     // set up channel
     let (logging_send, mut logging_recv) = mpsc::channel(32);
 
@@ -358,16 +448,15 @@ async fn get_instruction_result(
     // await for the instruction, which will send an end token at the end of the function:
     // OrchestrationInstruction::run(
     // so that the logging task will close itself, rather than needing us to cancel it
-    let instruction_result = instruction.run(&state, &common, &logging_send)
+    let instruction_result = instruction.run(&state, &common, &logging_send, cancel_token_recv)
         .await
         .context("getting instruction result")?;
-    let ws_sender = logging_task
+    let _ = logging_task
         .await
         .context("joining on command logging task")?
         .context("getting back websocket sender from logging task")?;
 
-
-    Ok((instruction_result, ws_sender))
+    Ok(instruction_result)
 }
 
 async fn get_init_protocol(
@@ -378,97 +467,23 @@ async fn get_init_protocol(
 }
 
 
-async fn process_client_instruction(
+/// Get the `OrchestrationProtocol` from the message. If the message was a websocket close then we
+/// return a `None` but this was still a successful message. If we receive anything else, then that
+/// is an error.
+async fn process_message(
     msg: Message,
-    loop_sender: Arc<Mutex<SplitSink<WebSocket, Message>>>,
-    loop_state: Arc<State>,
-    loop_common: OrchestrationCommon
-) -> anyhow::Result<bool> {
+) -> anyhow::Result<Option<OrchestrationProtocol>> {
     match msg {
         Message::Binary(b) => {
             // deserialise
             let instruction: OrchestrationProtocol = serde_json::from_slice(&b)?;
             tracing::info!("orchestration got instruction: {:?}", &instruction.instruction);
 
-            let _ = loop_sender.lock().await.send(Message::Text("Receiving instruction OK".into()))
-                .await
-                .context("sending acknowledgement")?;
-
-            // run the instruction, if the mpsc channel returns a message from the instruction
-            // while it is running, process that and then resume waiting for the instruction to run
-            // ... this will also handle sending any important log messages during the
-            // execution of the instruction to the client, that aren't the final state of
-            // the instruction result, as seen below `serialised_response`
-            let (run_instruction_res, loop_sender) = get_instruction_result(
-                instruction,
-                &loop_state,
-                &loop_common,
-                loop_sender.clone(),
-            ).await.context("getting result for instruction execution and ws sender")?;
-
-            // send to client the result
-            let serialised_response = serde_json::to_string(&run_instruction_res)?;
-            let _ = loop_sender.lock().await.send(Message::Text(serialised_response.into()))
-                .await
-                .context("sending instruction result")?;
-
-            if !run_instruction_res.is_success()? {
-                bail!("there was a failed orchestration instruction, {run_instruction_res:?}");
-            }
-
-            // dont close
-            Ok(false)
-
+            Ok(Some(instruction))
         }
         Message::Close(_) => {
-            return Ok(true);
+            Ok(None)
         }
-        _ => Ok(true), // TODO - unexpected message?
-    }
-}
-
-async fn process_potential_cancel_token(
-    maybe_cancel_token: Message,
-    loop_sender_cancel: Arc<Mutex<SplitSink<WebSocket, Message>>>,
-) -> anyhow::Result<bool> {
-
-    match maybe_cancel_token {
-        Message::Binary(b) => {
-
-            let instruction: OrchestrationProtocol = serde_json::from_slice(&b)?;
-            tracing::info!("orchestration got instruction in cancellation listener: {:?}", &instruction.instruction);
-
-            match instruction.instruction {
-                OrchestrationInstruction::Cancel => {}
-                _ => {
-                    // was not cancellation token, for now we will throw an error and kill the
-                    // command running as the following commands will be out of order for the
-                    // orchestration protocol
-                    // there is a strict order of commands from the client to the server
-                    bail!("got a non cancellation token in the cancellation listener, killing orchestration")
-                }
-            }
-
-            // as this is processing the cancel request during an instruction, rather than being
-            // processed between, we should send the client back the same response
-            let serialised_response = serde_json::to_string(&OrchestrationProtocolResponse::Generic {
-                is_success: false,
-                message: "Cancel request".to_string(),
-            })?;
-            let _ = loop_sender_cancel.lock().await.send(Message::Text(serialised_response.into()))
-                .await
-                .context("sending instruction result")?;
-
-            tracing::info!("client has sent a cancellation token, closing connection");
-            let _ = loop_sender_cancel.lock().await.send(Message::Close(Some(CloseFrame {
-                code: 1000,
-                reason: Utf8Bytes::from("The client sent a cancellation token, connection closed"),
-            }))).await.context("sending close to client websocket")?;
-            Ok(true)
-        }
-        Message::Close(_) => {
-            return Ok(true);
-        }
-        _ => Ok(true), // TODO - unexpected message?
+        _ => bail!("unsupported message type"),
     }
 }

--- a/kvm-compose/testbedos-server/src/orchestration/websocket.rs
+++ b/kvm-compose/testbedos-server/src/orchestration/websocket.rs
@@ -1,4 +1,3 @@
-use std::fmt::format;
 use std::sync::Arc;
 use anyhow::{bail, Context};
 use axum::extract::ws::{CloseFrame, Message, Utf8Bytes, WebSocket};

--- a/kvm-compose/testbedos-server/src/orchestration/websocket.rs
+++ b/kvm-compose/testbedos-server/src/orchestration/websocket.rs
@@ -327,24 +327,8 @@ async fn run(
                             }
                         }
                     }
-                    // cancel_response = cancel_response_recv_channel.recv() => {
-                    //     // if there was a cancel, then there will be a response with the cancel state
-                    //     if let Some(response) = cancel_response {
-                    //
-                    //     } else {
-                    //
-                    //     }
-                    // }
                     else => bail!("there was a problem in getting the message from the instruction_recv_channel"),
                 }
-                // if let Ok(instruction) = instruction_recv_channel.recv().await.context("receiving instruction message") {
-                //
-                //
-                // } else {
-                //     // instruction over channel was not Ok
-                //     bail!("there was a problem in getting the message from the instruction_recv_channel")
-                // }
-
             }
 
             Ok(())

--- a/util/privacy_tools/setup.sh
+++ b/util/privacy_tools/setup.sh
@@ -1,4 +1,4 @@
-RELEASE_VERSION=v1.0.2
+RELEASE_VERSION=27d98fab34c17e7537b539f6bc5fb0dd84f0fbbb
 
 echo "installing Frida-Tools repo"
 cd /var/lib/testbedos/tools/
@@ -10,21 +10,19 @@ if [ -d "Frida-Tools" ]; then
     sudo git pull
 else
     echo "Frida Tools does not exist, pulling from GitHub"
-    sudo git clone -b $RELEASE_VERSION https://github.com/Bristol-Cyber-Security-Group/Frida-Tools.git
+    sudo git clone https://github.com/Bristol-Cyber-Security-Group/Frida-Tools.git
     cd Frida-Tools || exit
+    sudo git checkout $RELEASE_VERSION || exit
 fi
 
 # set up a pip environment just for the frida tools
 FRIDA_VENV=/var/lib/testbedos/tools/frida_tools_venv
 sudo mkdir -p $FRIDA_VENV
 sudo chmod 777 $FRIDA_VENV
-python3 -m venv $FRIDA_VENV
-$FRIDA_VENV/bin/pip install -U pip setuptools
-$FRIDA_VENV/bin/pip install poetry
+sudo python3 -m venv $FRIDA_VENV
+sudo $FRIDA_VENV/bin/pip install -U pip setuptools
 
-# set up the python environment for the Frida-Tools
-# need to ignore keyring https://github.com/python-poetry/poetry/issues/8623
-sudo PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring $FRIDA_VENV/bin/poetry install
+sudo $FRIDA_VENV/bin/pip install -r requirements.txt
 
 # update the python path in test privacy script to the environment created just now
-sudo sed -i 's#PYTHON="/path/to/poetry/env/bin/python"#PYTHON="/var/lib/testbedos/tools/frida_tools_venv/bin/poetry run python"#g' /var/lib/testbedos/tools/Frida-Tools/test-privacy.sh
+sudo sed -i 's#PYTHON="/path/to/poetry/env/bin/python"#PYTHON="/var/lib/testbedos/tools/frida_tools_venv/bin/python"#g' /var/lib/testbedos/tools/Frida-Tools/test-privacy.sh

--- a/util/privacy_tools/setup.sh
+++ b/util/privacy_tools/setup.sh
@@ -1,4 +1,4 @@
-RELEASE_VERSION=27d98fab34c17e7537b539f6bc5fb0dd84f0fbbb
+RELEASE_VERSION=ff9c43d271cc696795c35fdd69b8a33ef9b10466
 
 echo "installing Frida-Tools repo"
 cd /var/lib/testbedos/tools/


### PR DESCRIPTION
This PR makes several upgrades to support the android based tooling.

- make sure that the frida server version is correct for the architecture of the emulator 
- Additional changes to how we install the repo containing our privacy tools - to use the requirements file directly with pip and the venv rather than poetry.
- significant reworking of the client-server comms
  - rework the cancellation token propagation from the client to server, necessary to be able to stop long running commands like the `tls-interceptor`
  - make the server return the end state of the command via the websocket, rather than checking on the REST api which is likely not yet updated
  - rework how we wait on the concurrent futures on the client side so that we capture error conditions, and also use future polling rather than a loop with `.is_finished()`
- make sure that we can properly kill processes created by the testbed by using process groups (used for killing tls-interceptor) by adding a new dependency `command-group`
- along the ctrl+c interrupt listener to propagate cancel tokens during command running, added another outer ctrl+c interrupt listener higher up the chain in case the CLI gets stuck