### PR TITLE
PTBED-330 - Fix mount test harness test case

### DIFF
--- a/kvm-compose/kvm-compose/assets/cloud_init.yaml
+++ b/kvm-compose/kvm-compose/assets/cloud_init.yaml
@@ -15,7 +15,10 @@ users:
 runcmd:
   - mkdir -p /etc/nocloud/context
   - mkdir /nocloudtmp
-  - mount /dev/sr0 /nocloudtmp
+  - |
+    # scsi0-0-0-0 corresponds to the scsi drive in the domain xml
+    ISO_DEV=$(readlink -f /dev/disk/by-id/*scsi0-0-0-0)
+    mount $ISO_DEV /nocloudtmp/ > /home/nocloud/context-mount.log
   - tar -xf /nocloudtmp/context.tar -C /etc/nocloud/context
   - umount /nocloudtmp
   - rm -rf /nocloudtmp

--- a/kvm-compose/kvm-compose/src/components/helpers/templates/libvirt_domain.xml
+++ b/kvm-compose/kvm-compose/src/components/helpers/templates/libvirt_domain.xml
@@ -26,6 +26,15 @@
         </disk>
         {% endif %}
 
+        <!-- leave a pre-defined CDROM definition in the guest for hot-swapping CDROM in libvirt version <= 8 -->
+        <disk type='file' device='cdrom'>
+            <driver name='qemu' type='raw'/>
+            <target dev='sdc' bus='scsi'/>
+            <readonly/>
+            <source file=''/>
+            <address type='drive' controller='0' bus='0' target='0' unit='2'/>
+        </disk>
+
         <graphics type="spice" autoport="yes">
             <listen type="address"/>
             <image compression="off"/>

--- a/kvm-compose/kvm-compose/src/components/helpers/templates/libvirt_domain.xml
+++ b/kvm-compose/kvm-compose/src/components/helpers/templates/libvirt_domain.xml
@@ -22,7 +22,8 @@
             <driver name="qemu" type="raw"></driver>
             <source file="{{ cloud_init_iso }}"></source>
             <readonly></readonly>
-            <target dev="hdb" bus="sata"></target>
+            <target dev="hdb" bus="scsi"></target>
+            <address type='drive' controller='0' bus='0' target='0' unit='0'/>
         </disk>
         {% endif %}
 

--- a/kvm-compose/kvm-compose/src/exec/docker.rs
+++ b/kvm-compose/kvm-compose/src/exec/docker.rs
@@ -13,7 +13,7 @@ pub async fn shell_command(
 ) -> anyhow::Result<(String, i32)> {
 
     // join the user command to the docker exec command
-    let mut docker_cmd = vec!["docker", "exec", guest_name_with_project];
+    let mut docker_cmd = vec!["docker", "exec", guest_name_with_project, "/bin/sh", "-c"];
     for cmd in command {
         docker_cmd.push(cmd);
     }

--- a/kvm-compose/kvm-compose/src/exec/docker.rs
+++ b/kvm-compose/kvm-compose/src/exec/docker.rs
@@ -14,9 +14,9 @@ pub async fn shell_command(
 
     // join the user command to the docker exec command
     let mut docker_cmd = vec!["docker", "exec", guest_name_with_project, "/bin/sh", "-c"];
-    for cmd in command {
-        docker_cmd.push(cmd);
-    }
+    let cmd = command.join(" ");
+    docker_cmd.push(&cmd);
+
     // run the command
     let cmd_res = run_subprocess_command(
         "sudo",

--- a/kvm-compose/kvm-compose/src/exec/file_transfer.rs
+++ b/kvm-compose/kvm-compose/src/exec/file_transfer.rs
@@ -225,6 +225,19 @@ pub async fn unmount_and_detach_cdrom_from_guest(
     // then detatch the device via libvirt
     let conn = Connect::open(Some("qemu:///system"))
         .context("connecting to libvirt to get detach CD ROM device")?;
+
+    // if the libvirt version is less than or equal to 8, then we need to leave this device plugged
+    // since libvirt doesn't support hotplug properly until version 9 and later, so we will skip
+    // the detach step
+
+    // they represent the version of the library the following way to factor in minor versions
+    let libvirt_version = conn.get_lib_version().context("Getting libvirt version before detach")?;
+    if libvirt_version <= 8_000_000 {
+        // version 8 or lower, skip detach
+        tracing::info!("Detaching CD ROM skipped due to libvirt version being version 8 or lower, version: {libvirt_version}");
+        return Ok(());
+    }
+
     let domain = virt::domain::Domain::lookup_by_name(&conn, guest_name_with_project)
         .context("getting domain from libvirt connection")?;
     // insert the scsi CD ROM device via an XML definition (will not persist between guest boots)

--- a/kvm-compose/kvm-compose/src/state/orchestration_tasks/guests.rs
+++ b/kvm-compose/kvm-compose/src/state/orchestration_tasks/guests.rs
@@ -415,6 +415,18 @@ impl OrchestrationGuestTask for ConfigLibvirtMachine {
                     wait_for_libvirt_guest_to_be_up(&common, &machine_config, vec!["ls"], logging_sender).await?;
                     let local_script_path = parse_path_with_deployment_config(script, &common)?;
 
+                    logging_sender.send(OrchestrationLogger::info(format!("Making sure cloud-init has completed on {guest_name} (Setup Action)"))).await?;
+                    let (_, _) = libvirt::shell_command(
+                        vec!["timeout", "300", "cloud-init", "status", "--wait"],
+                        1000*301,
+                        &machine_config,
+                        &guest_name,
+                        &common,
+                        logging_sender,
+                        true,
+                        false,
+                    ).await?;
+
                     logging_sender.send(OrchestrationLogger::info(format!("Pushing {local_script_path:?} to {guest_name}"))).await?;
                     libvirt::push(
                         &ExecCmdFileTransfer {
@@ -588,6 +600,19 @@ impl OrchestrationGuestTask for ConfigLibvirtMachine {
 
                     logging_sender.send(OrchestrationLogger::info(format!("Waiting until guest {guest_name} is up before continuing"))).await?;
                     wait_for_libvirt_guest_to_be_up(&common, &machine_config, vec!["ls"], logging_sender).await?;
+
+                    logging_sender.send(OrchestrationLogger::info(format!("Making sure cloud-init has completed on {guest_name} (Run Action)"))).await?;
+                    let (_, _) = libvirt::shell_command(
+                        vec!["timeout", "300", "cloud-init", "status", "--wait"],
+                        1000*301,
+                        &machine_config,
+                        &guest_name,
+                        &common,
+                        logging_sender,
+                        true,
+                        false,
+                    ).await?;
+
                     let local_script_path = parse_path_with_deployment_config(script, &common)?;
 
                     logging_sender.send(OrchestrationLogger::info(format!("Pushing {local_script_path:?} to {guest_name}"))).await?;

--- a/kvm-compose/kvm-compose/src/state/orchestration_tasks/guests.rs
+++ b/kvm-compose/kvm-compose/src/state/orchestration_tasks/guests.rs
@@ -863,9 +863,18 @@ impl OrchestrationGuestTask for ConfigDockerMachine {
             cmd_string.push("--env-file".to_string());
             // need to set the absolute path for env file since it might be running on remote
             if is_main_testbed(&common, testbed_host) {
-                cmd_string.push(format!("{env_file}"));
+
+                // join the path in the yaml if it is relative, to the project folder
+                let mut absolute_path = PathBuf::from(env_file);
+                if absolute_path.is_relative() {
+                    absolute_path = common.project_working_dir.join(&absolute_path);
+                }
+
+                cmd_string.push(format!("{}", absolute_path.to_string_lossy()));
             } else {
                 // on remote
+                // TODO - this is not going to work on remote, we need to define how we push artefacts
+                //  and especially those outside the project folder (or we say no to that for simplicity)
                 let remote_project_folder = get_remote_project_folder(&common, testbed_host)?;
                 cmd_string.push(format!("{remote_project_folder}/{env_file}"));
             }
@@ -882,7 +891,11 @@ impl OrchestrationGuestTask for ConfigDockerMachine {
                     // need to manually replace PWD as there is no shell
                     volume.source.replace("${PWD}", common.project_working_dir.to_str().unwrap())
                 } else {
-                    volume.source.clone()
+                    let mut absolute_path = PathBuf::from(&volume.source);
+                    if absolute_path.is_relative() {
+                        absolute_path = common.project_working_dir.join(&absolute_path);
+                    }
+                    absolute_path.to_string_lossy().into_owned()
                 };
                 cmd_string.push("-v".to_string());
                 // let mount_arg = format!("{}:{}", &volume.source, &volume.target);

--- a/test-harness/py_harness/test_cases/base.py
+++ b/test-harness/py_harness/test_cases/base.py
@@ -36,7 +36,7 @@ class BaseTestCase(TestCase):
         inter_docker_guest_connection = test_connection_between_guests(
             self.test_case_name,
             self.linked_clone_hosts,
-            "client1",
+            "nginx",
             "server",
             "10.0.0.11:8000",
             "_from_docker",

--- a/test-harness/py_harness/test_cases/mount.py
+++ b/test-harness/py_harness/test_cases/mount.py
@@ -84,4 +84,4 @@ class MountTestCase(TestCase):
             mount_docker,
         ]
 
-# registered_test_cases.append(MountTestCase)
+registered_test_cases.append(MountTestCase)

--- a/test-harness/py_harness/test_cases/mount.py
+++ b/test-harness/py_harness/test_cases/mount.py
@@ -74,13 +74,13 @@ class MountTestCase(TestCase):
         #     self.linked_clone_hosts,
         #     "_check_env_file_var_exists_docker",
         # )
-        # env_var_docker = run_command(
-        #     "client2",
-        #     """[ -n "${TWO}" ] && exit 0 || exit 1""",
-        #     self.test_case_name,
-        #     self.linked_clone_hosts,
-        #     "_check_env_var_exists_docker",
-        # )
+        env_var_docker = run_command(
+            "client2",
+            """'test $TWO = 2'""",
+            self.test_case_name,
+            self.linked_clone_hosts,
+            "_check_env_var_exists_docker",
+        )
         # mount_docker = run_command(
         #     "client2",
         #     "ls /opt/context",
@@ -97,7 +97,7 @@ class MountTestCase(TestCase):
             context_artefact,
             env_var,
             # env_file_var_docker,
-            # env_var_docker,
+            env_var_docker,
             # mount_docker,
         ]
 

--- a/test-harness/py_harness/test_cases/mount.py
+++ b/test-harness/py_harness/test_cases/mount.py
@@ -67,13 +67,13 @@ class MountTestCase(TestCase):
         )
 
         ## docker
-        # env_file_var_docker = run_command(
-        #     "client2",
-        #     """[ -n "${DOCKER_ENV}" ] && exit 0 || exit 1""",
-        #     self.test_case_name,
-        #     self.linked_clone_hosts,
-        #     "_check_env_file_var_exists_docker",
-        # )
+        env_file_var_docker = run_command(
+            "client2",
+            """'test $DOCKER_ENV = success'""",
+            self.test_case_name,
+            self.linked_clone_hosts,
+            "_check_env_file_var_exists_docker",
+        )
         env_var_docker = run_command(
             "client2",
             """'test $TWO = 2'""",
@@ -81,13 +81,14 @@ class MountTestCase(TestCase):
             self.linked_clone_hosts,
             "_check_env_var_exists_docker",
         )
-        # mount_docker = run_command(
-        #     "client2",
-        #     "ls /opt/context",
-        #     self.test_case_name,
-        #     self.linked_clone_hosts,
-        #     "_check_mount_exists_docker",
-        # )
+        # the contents of ./context/ in the yaml will be placed inside /opt (docker does not preserve the parent folder)
+        mount_docker = run_command(
+            "client2",
+            "ls /opt/context.txt",
+            self.test_case_name,
+            self.linked_clone_hosts,
+            "_check_mount_exists_docker",
+        )
 
         return [
             up_result_report,
@@ -96,9 +97,9 @@ class MountTestCase(TestCase):
             cloud_init_wait,
             context_artefact,
             env_var,
-            # env_file_var_docker,
+            env_file_var_docker,
             env_var_docker,
-            # mount_docker,
+            mount_docker,
         ]
 
 registered_test_cases.append(MountTestCase)

--- a/test-harness/py_harness/test_cases/mount.py
+++ b/test-harness/py_harness/test_cases/mount.py
@@ -44,22 +44,29 @@ class MountTestCase(TestCase):
             self.linked_clone_hosts,
             "_ensure_cloud_init_finished_running",
         )
+        # the context folder should be made, but also check if a file inside it exists to catch any bugs relating to
+        # zipping the context payload to be mounted into the guest
         context_artefact = run_command(
             "client1",
-            "ls /etc/nocloud/context/",
+            "ls /etc/nocloud/context/context.txt",
             self.test_case_name,
             self.linked_clone_hosts,
             "_check_context_artefact_exists",
         )
-        # env_var = run_command(
-        #     "client1",
-        #     """[ -n "${MOUNT_ENV_TEST}" ] && exit 0 || exit 1""",
-        #     self.test_case_name,
-        #     self.linked_clone_hosts,
-        #     "_check_env_var_exists",
-        # )
+        # this checks against the cloud-init environment tooling, we have not configured this to load permanently as
+        # that would require a VM restart after placing into /etc/environment
+        # ... this string here is a bit weird, needing to work around the limitations of how the kvm-compose exec
+        # command and python escape strings work - you need to send a string so that the $ isn't evaluated before being
+        # sent to the guest
+        env_var = run_command(
+            "client1",
+            r""" "test \$(cloud-init query ds.meta_data.environment.MOUNT_ENV_TEST) = 123" """,
+            self.test_case_name,
+            self.linked_clone_hosts,
+            "_check_env_var_exists",
+        )
 
-        ### docker
+        ## docker
         # env_file_var_docker = run_command(
         #     "client2",
         #     """[ -n "${DOCKER_ENV}" ] && exit 0 || exit 1""",
@@ -74,13 +81,13 @@ class MountTestCase(TestCase):
         #     self.linked_clone_hosts,
         #     "_check_env_var_exists_docker",
         # )
-        mount_docker = run_command(
-            "client2",
-            "ls /opt/context",
-            self.test_case_name,
-            self.linked_clone_hosts,
-            "_check_mount_exists_docker",
-        )
+        # mount_docker = run_command(
+        #     "client2",
+        #     "ls /opt/context",
+        #     self.test_case_name,
+        #     self.linked_clone_hosts,
+        #     "_check_mount_exists_docker",
+        # )
 
         return [
             up_result_report,
@@ -88,10 +95,10 @@ class MountTestCase(TestCase):
             setup_script_artefact,
             cloud_init_wait,
             context_artefact,
-            # env_var,
+            env_var,
             # env_file_var_docker,
             # env_var_docker,
-            mount_docker,
+            # mount_docker,
         ]
 
 registered_test_cases.append(MountTestCase)

--- a/test-harness/py_harness/test_cases/mount.py
+++ b/test-harness/py_harness/test_cases/mount.py
@@ -35,6 +35,15 @@ class MountTestCase(TestCase):
             self.linked_clone_hosts,
             "_check_setup_script_artefact_exists",
         )
+        # this is here so that we don't run the tests following before cloud-init finishes, meaning the context folder
+        # might not be available yet for example
+        cloud_init_wait = run_command(
+            "client1",
+            "timeout 300 cloud-init status --wait",
+            self.test_case_name,
+            self.linked_clone_hosts,
+            "_ensure_cloud_init_finished_running",
+        )
         context_artefact = run_command(
             "client1",
             "ls /etc/nocloud/context/",
@@ -77,6 +86,7 @@ class MountTestCase(TestCase):
             up_result_report,
             run_script_artefact,
             setup_script_artefact,
+            cloud_init_wait,
             context_artefact,
             # env_var,
             # env_file_var_docker,

--- a/test-harness/py_harness/test_cases/mount/kvm-compose.yaml
+++ b/test-harness/py_harness/test_cases/mount/kvm-compose.yaml
@@ -27,7 +27,7 @@ machines:
         ip: "10.0.0.12"
     docker:
       image: nginx:stable
-#      env_file: docker.env
+      env_file: docker.env
       environment:
         TWO: "2"
       volumes:


### PR DESCRIPTION
The test harness was failing on the mount test case. Turns out the issue lies with libvirt versions 8 and lower not yet providing an easy way to hotplug CDROMs. In version 9 and later this problem is fixed.

To work around this, we pre-define the CDROM in the libvirt domain xml in case we want to later use the CDROM for pushing files into the guest. And when clearing up after a file push, if the libvirt version is 8 or older, then we skip the detach step.