### PR TITLE
Add a consecutive up test for the test-harness in all test cases

### DIFF
--- a/test-harness/py_harness/main.py
+++ b/test-harness/py_harness/main.py
@@ -177,6 +177,10 @@ def main(connection: libvirt.virConnect) -> TestHarnessReport:
                     else:
                         n_host_report.clear_linked_clone_hosts = True
 
+            if not harness_settings.dev_mode:
+                # now that linked clones are destroyed, we can destroy the base host
+                base_host.ensure_destroyed()
+
 
     # clean up the test harness working area in the libvirt images folder
     if not harness_settings.dev_mode:

--- a/test-harness/py_harness/test_cases/base.py
+++ b/test-harness/py_harness/test_cases/base.py
@@ -44,11 +44,18 @@ class BaseTestCase(TestCase):
         )
         # TODO - to a docker guest
 
+        consecutive_up = down_then_up(
+            self.test_case_name,
+            "_consecutive_up",
+            self.linked_clone_hosts,
+        )
+
         return [
             up_result_report,
             libvirt_net_test_report,
             inter_libvirt_guest_connection,
             inter_docker_guest_connection,
+            consecutive_up,
         ]
 
 registered_test_cases.append(BaseTestCase)

--- a/test-harness/py_harness/test_cases/mount.py
+++ b/test-harness/py_harness/test_cases/mount.py
@@ -90,6 +90,12 @@ class MountTestCase(TestCase):
             "_check_mount_exists_docker",
         )
 
+        consecutive_up = down_then_up(
+            self.test_case_name,
+            "_consecutive_up",
+            self.linked_clone_hosts,
+        )
+
         return [
             up_result_report,
             run_script_artefact,
@@ -100,6 +106,7 @@ class MountTestCase(TestCase):
             env_file_var_docker,
             env_var_docker,
             mount_docker,
+            consecutive_up,
         ]
 
 registered_test_cases.append(MountTestCase)

--- a/test-harness/py_harness/test_cases/ovn.py
+++ b/test-harness/py_harness/test_cases/ovn.py
@@ -41,11 +41,18 @@ class OvnTestCase(TestCase):
 
         internet_test = confirm_no_internet_connectivity(self.test_case_name, self.linked_clone_hosts, merged_guests)
 
+        consecutive_up = down_then_up(
+            self.test_case_name,
+            "_consecutive_up",
+            self.linked_clone_hosts,
+        )
+
         return [
             up_result_report,
             sw0_to_sw1,
             sw1_to_sw0,
             internet_test,
+            consecutive_up,
         ]
 
 registered_test_cases.append(OvnTestCase)

--- a/test-harness/py_harness/test_cases/shared_runtime_tests.py
+++ b/test-harness/py_harness/test_cases/shared_runtime_tests.py
@@ -183,3 +183,31 @@ def run_command(
     report.success = True if command_process.returncode == 0 else False
     report.info = ""
     return report
+
+
+def down_then_up(
+    test_case_name: str,
+    test_report_name: str,
+    linked_clone_hosts: List[LinkedCloneHost],
+) -> TestReport:
+    # bring down the deployment and then bring it back up again to test consecutive ups
+    test_case = f"{test_case_location}/{test_case_name}"
+    report = TestReport(inspect.currentframe().f_code.co_name + test_report_name + "_" + test_case_name)
+    logging.info(f"Running test {report.test_name}")
+
+    down_result: subprocess.CompletedProcess = ssh_command(
+        f"cd {test_case} && kvm-compose down",
+        base_ssh_key,
+        linked_clone_hosts[0].hostname,  # first host will be main
+    )
+
+    up_result: subprocess.CompletedProcess = ssh_command(
+        f"cd {test_case} && kvm-compose up",
+        base_ssh_key,
+        linked_clone_hosts[0].hostname,  # first host will be main
+    )
+
+    # both the down and up must be a success
+    report.success = True if down_result.returncode == 0 and up_result.returncode == 0 else False
+    report.info = ""
+    return report


### PR DESCRIPTION
This PR adds a check to make sure bringing up a deployment, followed by a down then up again will be okay.