### PR TITLE
Make sure that the base host is cleaned up at the end of a harness run

### DIFF
--- a/test-harness/py_harness/main.py
+++ b/test-harness/py_harness/main.py
@@ -177,6 +177,10 @@ def main(connection: libvirt.virConnect) -> TestHarnessReport:
                     else:
                         n_host_report.clear_linked_clone_hosts = True
 
+            if not harness_settings.dev_mode:
+                # now that linked clones are destroyed, we can destroy the base host
+                base_host.ensure_destroyed()
+
 
     # clean up the test harness working area in the libvirt images folder
     if not harness_settings.dev_mode:


### PR DESCRIPTION
After each test-harness run, we are left with the definition of the base host. This needs to be cleaned up, but it also prevents us from re-running a pipeline as the name of the VM is already defined. We could make the code more robust and un-define it on the start of the test-harness but for now lets clean up this way to keep observing how the test-harness fails to pick up on any remaining logic bugs.

The output of `sudo virsh list --all` for example:

```
testbed-host-base-0547b663e2b38a63db615a0360e99ecb0d3e2345
testbed-host-base-0f1fd676862141667671e7006f3573641aa55395
testbed-host-base-101f2fb17f26b2c3eff8f8a8768f8589f7d1f29b
testbed-host-base-10a75847d108f71e352a9b6094f1c7eb22210e37
testbed-host-base-1ac363cd853b17a445a7651e22557a3fa625602a
testbed-host-base-1b3c0c4d4fff6f38e41183cebec3886f406375fb
```

So the test for this is to let this PR test-harness run, check if there is no remaining definition at the end, and then try to re-run the test-harness.