### PR TITLE
Actions Workflow on push to develop+main

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,6 +1,12 @@
 name: documentation
 
-on: [pull_request, workflow_dispatch]
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - develop
 
 permissions:
   contents: write

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -1,6 +1,12 @@
 name: rust-test
 
-on: [pull_request, workflow_dispatch]
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - develop
 
 jobs:
   run-cargo-test:

--- a/.github/workflows/test-harness.yml
+++ b/.github/workflows/test-harness.yml
@@ -1,6 +1,12 @@
 name: test-harness
 
-on: [pull_request, workflow_dispatch]
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - develop
 
 # This only works on main/default branches?
 #on:


### PR DESCRIPTION
This PR makes sure our actions workflows run on push to the develop and main branches.
Before this, actions would only trigger in a PR, but we need to make sure after a PR is merged into develop or main we get a test once more.