### PR TITLE
Allow test harness to run on develop and main

### DIFF
--- a/.github/workflows/test-harness.yml
+++ b/.github/workflows/test-harness.yml
@@ -21,15 +21,20 @@ jobs:
 #    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v4
+      - name: get commit sha
+        id: set_sha
+        run: |
+          SHA=$(git rev-parse HEAD)
+          echo "$COMMIT_SHA=$SHA" >> "$GITHUB_ENV"
       - name: build-harness-image
         run: |
-          cd test-harness && docker image build -t test-harness:${{ github.sha }} .
+          cd test-harness && docker image build -t test-harness:$COMMIT_SHA .
       - name: run-test-harness
         run: |
           cd test-harness && docker run \
             -v /var/run/libvirt/libvirt-sock:/var/run/libvirt/libvirt-sock \
             -v /var/lib/libvirt/images:/var/lib/libvirt/images --network=host \
-            -e COMMIT_HASH=${{ github.sha }} --rm test-harness:${{ github.sha }}
+            -e COMMIT_HASH=$COMMIT_SHA --rm test-harness:$COMMIT_SHA
       - name: cleanup
         run: |
-          docker image rm test-harness:${{ github.sha }}
+          docker image rm test-harness:$COMMIT_SHA

--- a/.github/workflows/test-harness.yml
+++ b/.github/workflows/test-harness.yml
@@ -23,13 +23,13 @@ jobs:
       - uses: actions/checkout@v4
       - name: build-harness-image
         run: |
-          cd test-harness && docker image build -t test-harness:${{ github.event.pull_request.head.sha }} .
+          cd test-harness && docker image build -t test-harness:${{ github.sha }} .
       - name: run-test-harness
         run: |
           cd test-harness && docker run \
             -v /var/run/libvirt/libvirt-sock:/var/run/libvirt/libvirt-sock \
             -v /var/lib/libvirt/images:/var/lib/libvirt/images --network=host \
-            -e COMMIT_HASH=${{ github.event.pull_request.head.sha }} --rm test-harness:${{ github.event.pull_request.head.sha }}
+            -e COMMIT_HASH=${{ github.sha }} --rm test-harness:${{ github.sha }}
       - name: cleanup
         run: |
-          docker image rm test-harness:${{ github.event.pull_request.head.sha }}
+          docker image rm test-harness:${{ github.sha }}

--- a/.github/workflows/test-harness.yml
+++ b/.github/workflows/test-harness.yml
@@ -22,9 +22,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: get commit sha
-        id: set_sha
         run: |
-          SHA=$(git rev-parse HEAD)
+          SHA="${{ github.event.pull_request.head.sha || github.sha }}"
           echo "COMMIT_SHA=$SHA" >> "$GITHUB_ENV"
       - name: build-harness-image
         run: |

--- a/.github/workflows/test-harness.yml
+++ b/.github/workflows/test-harness.yml
@@ -25,7 +25,7 @@ jobs:
         id: set_sha
         run: |
           SHA=$(git rev-parse HEAD)
-          echo "$COMMIT_SHA=$SHA" >> "$GITHUB_ENV"
+          echo "COMMIT_SHA=$SHA" >> "$GITHUB_ENV"
       - name: build-harness-image
         run: |
           cd test-harness && docker image build -t test-harness:$COMMIT_SHA .


### PR DESCRIPTION
The workflows were set to take the pull request sha, instead we take the current commit sha so that the test harness can run on the develop and main branches, after a merge from a pull request.